### PR TITLE
Redirect to workspace after login

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,29 +1,22 @@
-import { Routes, Route, BrowserRouter } from 'react-router-dom';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import Navbar from './components/Navbar';
 import About from './components/About';
 import Careers from './components/Careers';
 import LandingPage from './components/LandingPage';
+import Workspace from './components/Workspace';
 import Footer from './components/Footer';
-
 
 export default function App() {
   return (
-    <>
-     <BrowserRouter>
-       <Navbar />
+    <BrowserRouter>
+      <Navbar />
       <Routes>
-        <Route path="/" element={<LandingPage />} /> 
+        <Route path="/" element={<LandingPage />} />
         <Route path="/about" element={<About />} />
-        <Route path="/careers" element={<Careers />} /> 
-      
-
+        <Route path="/careers" element={<Careers />} />
+        <Route path="/workspace" element={<Workspace />} />
       </Routes>
-      <Footer/>  
-
-      </BrowserRouter> */
-    
-
-     
-    </>
+      <Footer />
+    </BrowserRouter>
   );
 }

--- a/src/components/GoogleLogin.jsx
+++ b/src/components/GoogleLogin.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 const BACKEND_URL = 'http://localhost:8000';
 
@@ -6,6 +7,7 @@ export default function GoogleLogin() {
   const [user, setUser] = useState(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
+  const navigate = useNavigate();
 
   // Initialize Google Identity Services client once
   useEffect(() => {
@@ -48,6 +50,7 @@ export default function GoogleLogin() {
       localStorage.setItem('user', JSON.stringify(backendUser));
       localStorage.setItem('token', appJwt);
       setUser(backendUser);
+      navigate('/workspace');
     } catch (err) {
       setError(err.message);
       setUser(null);

--- a/src/components/Workspace.jsx
+++ b/src/components/Workspace.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function Workspace() {
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-16">
+      <h2 className="text-3xl font-semibold mb-4">Workspace</h2>
+      <p className="text-gray-700">Welcome to your workspace!</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add new workspace component
- wire `/workspace` route
- redirect to `/workspace` after Google login

## Testing
- `npm run lint` *(fails: eslint not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6884fae531908320a2ada645abe58942