### PR TITLE
Add Google login flow and workspace routing

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -31,11 +31,14 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import Navbar from './components/Navbar';
 import Footer from './components/Footer';
 
-import LandingPage     from './components/LandingPage';
-import PrivacyPolicy   from './components/PrivacyPolicy';
-import CookiePolicy    from './components/CookiePolicy';
-import TermsOfService  from './components/TermsOfService';
-import GDPRCompliance  from './components/GDPRCompliance';
+import LandingPage from './components/LandingPage';
+import PrivacyPolicy from './components/PrivacyPolicy';
+import CookiePolicy from './components/CookiePolicy';
+import TermsOfService from './components/TermsOfService';
+import GDPRCompliance from './components/GDPRCompliance';
+import GoogleLogin from './components/GoogleLogin';
+import Workspace from './components/Workspace';
+import ErrorPage from './components/ErrorPage';
 
 import {landingContent} from './components/landingContent'; 
 
@@ -54,12 +57,15 @@ export default function App() {
       />
 
       <Routes>
-        <Route path="/"       element={<LandingPage theme ={theme} />} />
+        <Route path="/" element={<LandingPage theme={theme} />} />
+        <Route path="login" element={<GoogleLogin />} />
+        <Route path="workspace" element={<Workspace />} />
+        <Route path="error" element={<ErrorPage />} />
         <Route path="privacy" element={<PrivacyPolicy />} />
         <Route path="cookies" element={<CookiePolicy />} />
-        <Route path="terms"   element={<TermsOfService />} />
-        <Route path="gdpr"    element={<GDPRCompliance />} />
-        <Route path="*"       element={<p>404 Not Found</p>} />
+        <Route path="terms" element={<TermsOfService />} />
+        <Route path="gdpr" element={<GDPRCompliance />} />
+        <Route path="*" element={<p>404 Not Found</p>} />
       </Routes>
 
     

--- a/src/components/ErrorPage.jsx
+++ b/src/components/ErrorPage.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function ErrorPage() {
+  return (
+    <div className="h-screen flex items-center justify-center">
+      <h1 className="text-2xl font-semibold text-red-600">Something went wrong. Please try again.</h1>
+    </div>
+  );
+}

--- a/src/components/GoogleLogin.jsx
+++ b/src/components/GoogleLogin.jsx
@@ -56,6 +56,7 @@ export default function GoogleLogin() {
       setUser(null);
       localStorage.removeItem('user');
       localStorage.removeItem('token');
+      navigate('/error');
     } finally {
       setLoading(false);
     }

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -139,6 +139,7 @@
 // export default Navbar;
 // Navbar.jsx
 import { useState } from 'react';
+import { Link } from 'react-router-dom';
 import {
   Sparkles,
   Sun,
@@ -211,9 +212,12 @@ const Navbar = ({ theme, toggleTheme, navigation }) => {
           >
             {theme === 'light' ? <Moon size={20} /> : <Sun size={20} />}
           </button>
-          <button className={`rounded-full px-5 py-2 text-sm font-semibold shadow-md transition ${cfg.primaryBtn}`}>
+          <Link
+            to="/login"
+            className={`rounded-full px-5 py-2 text-sm font-semibold shadow-md transition ${cfg.primaryBtn}`}
+          >
             {navigation.ctaButton}
-          </button>
+          </Link>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- start Google login when clicking `Get Started`
- redirect users to Workspace on successful login and to an error page on failure
- add routes for login, workspace and error pages
- link Get Started button to the login route

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b10c692d48320be0b024c07666dcc