### PR TITLE
Implement workspace layout with themed navigation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -26,10 +26,9 @@
 // }
 
 import React, { useState } from 'react';
-import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, Navigate, useLocation } from 'react-router-dom';
 
 import Navbar from './components/Navbar';
-import Footer from './components/Footer';
 
 import LandingPage from './components/LandingPage';
 import PrivacyPolicy from './components/PrivacyPolicy';
@@ -44,30 +43,52 @@ import {landingContent} from './components/landingContent';
 
 export default function App() {
   const [theme, setTheme] = useState('light');
-  const toggleTheme = () => setTheme( prev => ( prev  === 'light' ? 'dark' : 'light'));
-
-  const isLoggedIn = () => Boolean(localStorage.getItem('token'));
-
-  const { navigation, footer } = landingContent;
+  const toggleTheme = () =>
+    setTheme((prev) => (prev === 'light' ? 'dark' : 'light'));
 
   return (
     <BrowserRouter>
-      <Navbar
-        theme={theme}
-        toggleTheme={toggleTheme}
-        navigation={navigation}
-      />
+      <AppRoutes theme={theme} toggleTheme={toggleTheme} />
+    </BrowserRouter>
+  );
+}
 
+function AppRoutes({ theme, toggleTheme }) {
+  const isLoggedIn = () => Boolean(localStorage.getItem('token'));
+  const { navigation } = landingContent;
+  const location = useLocation();
+  const isWorkspace = location.pathname.startsWith('/workspace');
+
+  return (
+    <>
+      {!isWorkspace && (
+        <Navbar
+          theme={theme}
+          toggleTheme={toggleTheme}
+          navigation={navigation}
+        />
+      )}
       <Routes>
         <Route
           path="/"
-          element={isLoggedIn() ? <Navigate to="/workspace" replace /> : <LandingPage theme={theme} />}
+          element={
+            isLoggedIn() ? (
+              <Navigate to="/workspace" replace />
+            ) : (
+              <LandingPage theme={theme} />
+            )
+          }
         />
         <Route
           path="login"
-          element={isLoggedIn() ? <Navigate to="/workspace" replace /> : <GoogleLogin />}
+          element={
+            isLoggedIn() ? <Navigate to="/workspace" replace /> : <GoogleLogin />
+          }
         />
-        <Route path="workspace" element={<Workspace />} />
+        <Route
+          path="workspace/*"
+          element={<Workspace theme={theme} toggleTheme={toggleTheme} />}
+        />
         <Route path="error" element={<ErrorPage />} />
         <Route path="privacy" element={<PrivacyPolicy />} />
         <Route path="cookies" element={<CookiePolicy />} />
@@ -75,8 +96,6 @@ export default function App() {
         <Route path="gdpr" element={<GDPRCompliance />} />
         <Route path="*" element={<p>404 Not Found</p>} />
       </Routes>
-
-    
-    </BrowserRouter>
+    </>
   );
 }

--- a/src/components/LectureHall.jsx
+++ b/src/components/LectureHall.jsx
@@ -1,0 +1,8 @@
+export default function LectureHall() {
+  return (
+    <div className="p-6">
+      <h2 className="text-2xl font-semibold mb-4">Lecture Hall</h2>
+      <p>Join live sessions and watch lectures here.</p>
+    </div>
+  );
+}

--- a/src/components/Library.jsx
+++ b/src/components/Library.jsx
@@ -1,0 +1,8 @@
+export default function Library() {
+  return (
+    <div className="p-6">
+      <h2 className="text-2xl font-semibold mb-4">Library</h2>
+      <p>Here you can access all your saved notes and resources.</p>
+    </div>
+  );
+}

--- a/src/components/Workspace.jsx
+++ b/src/components/Workspace.jsx
@@ -1,10 +1,24 @@
-import React from 'react';
+import { Routes, Route } from 'react-router-dom';
+import themeConfig from './themeConfig';
+import WorkspaceNavbar from './WorkspaceNavbar';
+import WorkspaceFooter from './WorkspaceFooter';
+import Library from './Library';
+import LectureHall from './LectureHall';
+import NotesDashboard from './NotesDashboard';
 
-export default function Workspace() {
+export default function Workspace({ theme, toggleTheme }) {
+  const cfg = themeConfig[theme];
   return (
-    <div className="max-w-3xl mx-auto px-4 py-16">
-      <h2 className="text-3xl font-semibold mb-4">Workspace</h2>
-      <p className="text-gray-700">Welcome to your workspace!</p>
+    <div className={cfg.root}>
+      <WorkspaceNavbar theme={theme} toggleTheme={toggleTheme} />
+      <main className="min-h-screen px-4 py-6">
+        <Routes>
+          <Route index element={<NotesDashboard />} />
+          <Route path="library" element={<Library />} />
+          <Route path="lecturehall" element={<LectureHall />} />
+        </Routes>
+      </main>
+      <WorkspaceFooter theme={theme} />
     </div>
   );
 }

--- a/src/components/WorkspaceFooter.jsx
+++ b/src/components/WorkspaceFooter.jsx
@@ -1,0 +1,10 @@
+import themeConfig from './themeConfig';
+
+export default function WorkspaceFooter({ theme }) {
+  const cfg = themeConfig[theme];
+  return (
+    <footer className={`text-center py-4 ${cfg.cardBg} ${cfg.borderTop}`}> 
+      <p className={cfg.text}>© 2025 EduNote</p>
+    </footer>
+  );
+}

--- a/src/components/WorkspaceNavbar.jsx
+++ b/src/components/WorkspaceNavbar.jsx
@@ -1,0 +1,43 @@
+import { Link, NavLink, useNavigate } from 'react-router-dom';
+import { Sun, Moon, BookOpen, GraduationCap, UserCircle, LogOut } from 'lucide-react';
+import themeConfig from './themeConfig';
+
+export default function WorkspaceNavbar({ theme, toggleTheme }) {
+  const cfg = themeConfig[theme];
+  const navigate = useNavigate();
+  const username = localStorage.getItem('userName') || 'User';
+
+  const handleLogout = () => {
+    localStorage.removeItem('token');
+    navigate('/');
+  };
+
+  return (
+    <header className={`flex items-center justify-between px-4 py-3 border-b ${cfg.headerBorder} ${cfg.headerBg}`}> 
+      <Link to="/workspace" className="flex items-center gap-2 font-semibold">
+        <BookOpen size={20} className={cfg.icon} />
+        <span>EduNote</span>
+      </Link>
+      <nav className="flex items-center gap-4 text-sm">
+        <NavLink to="/workspace/library" className={({isActive}) => isActive ? 'font-semibold' : cfg.navLink }>
+          Library
+        </NavLink>
+        <NavLink to="/workspace/lecturehall" className={({isActive}) => isActive ? 'font-semibold' : cfg.navLink }>
+          Lecture Hall
+        </NavLink>
+      </nav>
+      <div className="flex items-center gap-4">
+        <button onClick={toggleTheme} aria-label="Toggle theme" className={cfg.icon}>
+          {theme === 'light' ? <Moon size={18}/> : <Sun size={18}/>}
+        </button>
+        <div className="flex items-center gap-2">
+          <UserCircle size={20} className={cfg.icon} />
+          <span className="text-sm">{username}</span>
+          <button onClick={handleLogout} aria-label="Logout" className={cfg.icon}>
+            <LogOut size={18} />
+          </button>
+        </div>
+      </div>
+    </header>
+  );
+}


### PR DESCRIPTION
## Summary
- add new Workspace layout with navbar, body routing, and footer
- include new routes for library and lecture hall views
- update App router to show workspace layout and conditional landing navbar
- add simple Library and LectureHall pages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_688b1da556b883209150f4fab1935e66