### PR TITLE
Fix navbar username and cleanup on logout

### DIFF
--- a/src/components/WorkspaceNavbar.jsx
+++ b/src/components/WorkspaceNavbar.jsx
@@ -5,10 +5,23 @@ import themeConfig from './themeConfig';
 export default function WorkspaceNavbar({ theme, toggleTheme }) {
   const cfg = themeConfig[theme];
   const navigate = useNavigate();
-  const username = localStorage.getItem('userName') || 'User';
+  let username = 'User';
+  const storedUser = localStorage.getItem('user');
+  if (storedUser) {
+    try {
+      const userObj = JSON.parse(storedUser);
+      username = userObj.name || userObj.username || 'User';
+    } catch (e) {
+      // ignore parse errors and use default username
+    }
+  }
 
   const handleLogout = () => {
     localStorage.removeItem('token');
+    localStorage.removeItem('user');
+    if (window.google?.accounts?.id?.disableAutoSelect) {
+      window.google.accounts.id.disableAutoSelect();
+    }
     navigate('/');
   };
 


### PR DESCRIPTION
## Summary
- show the logged in user's name in `WorkspaceNavbar`
- clear both token and user info on logout
- disable Google auto-login to show sign-in page when returning from logout

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_688b24e1dddc832087d2d89606b3ab62