### PR TITLE
Add basic audio recording

### DIFF
--- a/src/components/AudioRecorderContext.jsx
+++ b/src/components/AudioRecorderContext.jsx
@@ -1,0 +1,63 @@
+import React, { createContext, useContext, useRef, useState } from 'react';
+
+const RecordingContext = createContext({
+  isRecording: false,
+  chunks: [],
+  transcript: null,
+  start: () => {},
+  stop: () => {}
+});
+
+const RECORDING_ICON =
+  'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><circle cx="8" cy="8" r="8" fill="%23ff0000"/></svg>';
+const DEFAULT_ICON = '/vite.svg';
+
+function setFavicon(recording) {
+  const link = document.querySelector("link[rel='icon']");
+  if (link) {
+    link.href = recording ? RECORDING_ICON : DEFAULT_ICON;
+  }
+}
+
+export function AudioRecorderProvider({ children }) {
+  const [isRecording, setIsRecording] = useState(false);
+  const [chunks, setChunks] = useState([]);
+  const [transcript, setTranscript] = useState(null);
+  const mediaRecorderRef = useRef(null);
+
+  const start = async () => {
+    if (isRecording) return;
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      mediaRecorderRef.current = new MediaRecorder(stream);
+      mediaRecorderRef.current.ondataavailable = (e) => {
+        if (e.data && e.data.size > 0) {
+          setChunks((prev) => [...prev, e.data]);
+        }
+      };
+      mediaRecorderRef.current.start(10000);
+      setIsRecording(true);
+      setFavicon(true);
+    } catch (err) {
+      console.error('Unable to start audio recording', err);
+    }
+  };
+
+  const stop = () => {
+    if (mediaRecorderRef.current) {
+      mediaRecorderRef.current.stop();
+      mediaRecorderRef.current.stream.getTracks().forEach((t) => t.stop());
+      mediaRecorderRef.current = null;
+    }
+    setIsRecording(false);
+    setFavicon(false);
+  };
+
+  return (
+    <RecordingContext.Provider value={{ isRecording, chunks, transcript, setTranscript, start, stop }}>
+      {children}
+    </RecordingContext.Provider>
+  );
+}
+
+export const useAudioRecorder = () => useContext(RecordingContext);

--- a/src/components/AudioRecorderContext.jsx
+++ b/src/components/AudioRecorderContext.jsx
@@ -28,8 +28,12 @@ export function AudioRecorderProvider({ children }) {
   const start = async () => {
     if (isRecording) return;
     try {
-      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-      mediaRecorderRef.current = new MediaRecorder(stream);
+      const stream = await navigator.mediaDevices.getDisplayMedia({
+        video: true,
+        audio: true,
+      });
+      const audioStream = new MediaStream(stream.getAudioTracks());
+      mediaRecorderRef.current = new MediaRecorder(audioStream);
       mediaRecorderRef.current.ondataavailable = (e) => {
         if (e.data && e.data.size > 0) {
           setChunks((prev) => [...prev, e.data]);

--- a/src/components/WorkspaceLanding.jsx
+++ b/src/components/WorkspaceLanding.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useAudioRecorder } from './AudioRecorderContext.jsx';
 import { useNavigate } from 'react-router-dom';
 import { AlertCircle, PlayCircle } from 'lucide-react';
 import themeConfig from './themeConfig';
@@ -20,11 +21,17 @@ export default function WorkspaceLanding({ theme }) {
   const [error, setError] = useState('');
   const navigate = useNavigate();
   const cfg = themeConfig[theme];
+  const { start, setTranscript } = useAudioRecorder();
 
   const handleSubmit = (e) => {
     e.preventDefault();
     if (isValidYouTubeUrl(url)) {
       setError('');
+      if (window.currentTranscript) {
+        setTranscript(window.currentTranscript);
+      } else {
+        start();
+      }
       navigate(`/workspace/lecturehall?video=${encodeURIComponent(url)}`);
     } else {
       setError('Please enter a valid YouTube URL');

--- a/src/components/WorkspaceNavbar.jsx
+++ b/src/components/WorkspaceNavbar.jsx
@@ -1,9 +1,11 @@
 import { Link, NavLink, useNavigate } from 'react-router-dom';
-import { Sun, Moon, BookOpen, GraduationCap, UserCircle, LogOut } from 'lucide-react';
+import { Sun, Moon, BookOpen, GraduationCap, UserCircle, LogOut, Mic } from 'lucide-react';
 import themeConfig from './themeConfig';
+import { useAudioRecorder } from './AudioRecorderContext.jsx';
 
 export default function WorkspaceNavbar({ theme, toggleTheme }) {
   const cfg = themeConfig[theme];
+  const { isRecording } = useAudioRecorder();
   const navigate = useNavigate();
   let username = 'User';
   const storedUser = localStorage.getItem('user');
@@ -43,6 +45,7 @@ export default function WorkspaceNavbar({ theme, toggleTheme }) {
         <button onClick={toggleTheme} aria-label="Toggle theme" className={cfg.icon}>
           {theme === 'light' ? <Moon size={18}/> : <Sun size={18}/>}
         </button>
+        {isRecording && <Mic size={18} className="text-red-500" />}
         <div className="flex items-center gap-2">
           <UserCircle size={20} className={cfg.icon} />
           <span className="text-sm">{username}</span>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,12 +1,13 @@
-import { StrictMode } from "react";
-import { createRoot } from "react-dom/client";
-import App from "./App.jsx";
-import "./index.css";
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App.jsx';
+import { AudioRecorderProvider } from './components/AudioRecorderContext.jsx';
+import './index.css';
 
 createRoot(document.getElementById("root")).render(
   <StrictMode>
-
+    <AudioRecorderProvider>
       <App />
-    
+    </AudioRecorderProvider>
   </StrictMode>
 );


### PR DESCRIPTION
## Summary
- create `AudioRecorderContext` for recording tab audio
- start recording from Workspace landing page
- show recording status in Workspace navbar
- wrap app with the new provider

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_688b36c8985c8320bd666261d3047c2e