### PR TITLE
Add lecture hall side panels and pause video

### DIFF
--- a/src/components/LectureHall.jsx
+++ b/src/components/LectureHall.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import { HelpCircle, PencilLine, ClipboardList, ArrowLeft } from 'lucide-react';
 import themeConfig from './themeConfig';
@@ -23,6 +23,24 @@ export default function LectureHall({ theme }) {
   const videoId = extractId(videoUrl);
   const cfg = themeConfig[theme];
   const { stop } = useAudioRecorder();
+  const [activePanel, setActivePanel] = useState(null);
+  const iframeRef = useRef(null);
+
+  const pauseVideo = () => {
+    if (iframeRef.current) {
+      iframeRef.current.contentWindow.postMessage(
+        '{"event":"command","func":"pauseVideo","args":""}',
+        '*'
+      );
+    }
+  };
+
+  const openPanel = (panel) => {
+    pauseVideo();
+    setActivePanel(panel);
+  };
+
+  const closePanel = () => setActivePanel(null);
 
   useEffect(() => {
     return () => {
@@ -43,10 +61,12 @@ export default function LectureHall({ theme }) {
         <ArrowLeft size={18} /> Back
       </button>
       {videoId ? (
-        <div className="space-y-6 max-w-4xl mx-auto">
+        <>
+        <div className="space-y-6 max-w-5xl mx-auto">
           <div className="rounded-2xl overflow-hidden shadow-lg aspect-video">
             <iframe
-              src={`https://www.youtube.com/embed/${videoId}`}
+              ref={iframeRef}
+              src={`https://www.youtube.com/embed/${videoId}?enablejsapi=1`}
               title="YouTube video"
               className="w-full h-full"
               allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
@@ -54,17 +74,46 @@ export default function LectureHall({ theme }) {
             />
           </div>
           <div className="flex justify-center gap-4">
-            <button className={`flex items-center gap-2 px-4 py-2 rounded-full ${cfg.primaryBtn}`}>
+            <button
+              onClick={() => openPanel('doubt')}
+              className={`flex items-center gap-2 px-4 py-2 rounded-full ${cfg.primaryBtn}`}
+            >
               <HelpCircle size={18} /> Ask Doubt
             </button>
-            <button className={`flex items-center gap-2 px-4 py-2 rounded-full ${cfg.secondaryBtn}`}>
+            <button
+              onClick={() => openPanel('notes')}
+              className={`flex items-center gap-2 px-4 py-2 rounded-full ${cfg.secondaryBtn}`}
+            >
               <PencilLine size={18} /> Write Notes
             </button>
-            <button className={`flex items-center gap-2 px-4 py-2 rounded-full ${cfg.secondaryBtn}`}>
+            <button
+              onClick={() => openPanel('test')}
+              className={`flex items-center gap-2 px-4 py-2 rounded-full ${cfg.secondaryBtn}`}
+            >
               <ClipboardList size={18} /> Test Yourself
             </button>
           </div>
         </div>
+        <aside
+          className={`fixed top-0 right-0 w-80 max-w-full h-full shadow-xl transition-transform transform ${activePanel ? 'translate-x-0' : 'translate-x-full'} ${theme === 'light' ? 'bg-white' : 'bg-[#0c1424]'}`}
+        >
+          <div className="flex items-center justify-between p-4 border-b border-slate-200/50">
+            <h2 className="font-semibold capitalize">{activePanel ? activePanel : ''}</h2>
+            <button onClick={closePanel} aria-label="Close" className="text-xl">×</button>
+          </div>
+          <div className="p-4 overflow-y-auto space-y-4">
+            {activePanel === 'doubt' && (
+              <p>Here you can ask your questions about the lecture.</p>
+            )}
+            {activePanel === 'notes' && (
+              <textarea className="w-full h-40 p-2 rounded border" placeholder="Write your notes here" />
+            )}
+            {activePanel === 'test' && (
+              <p>Test yourself with quizzes coming soon!</p>
+            )}
+          </div>
+        </aside>
+        </>
       ) : (
         <p className="text-center">No video selected.</p>
       )}


### PR DESCRIPTION
## Summary
- enlarge the lecture hall video container
- add interactive side panels for Ask Doubt, Write Notes and Test Yourself
- pause the video when any panel opens

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_688b4e70a3c88320be1229ea0d33aab8