### PR TITLE
Fix video input and rename workspace route

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -57,7 +57,7 @@ function AppRoutes({ theme, toggleTheme }) {
   const isLoggedIn = () => Boolean(localStorage.getItem('token'));
   const { navigation } = landingContent;
   const location = useLocation();
-  const isWorkspace = location.pathname.startsWith('/workspace');
+  const isWorkspace = location.pathname.startsWith('/platform');
 
   return (
     <>
@@ -73,7 +73,7 @@ function AppRoutes({ theme, toggleTheme }) {
           path="/"
           element={
             isLoggedIn() ? (
-              <Navigate to="/workspace" replace />
+              <Navigate to="/platform" replace />
             ) : (
               <LandingPage theme={theme} />
             )
@@ -82,11 +82,11 @@ function AppRoutes({ theme, toggleTheme }) {
         <Route
           path="login"
           element={
-            isLoggedIn() ? <Navigate to="/workspace" replace /> : <GoogleLogin />
+            isLoggedIn() ? <Navigate to="/platform" replace /> : <GoogleLogin />
           }
         />
         <Route
-          path="workspace/*"
+          path="platform/*"
           element={<Workspace theme={theme} toggleTheme={toggleTheme} />}
         />
         <Route path="error" element={<ErrorPage />} />

--- a/src/components/GoogleLogin.jsx
+++ b/src/components/GoogleLogin.jsx
@@ -50,7 +50,7 @@ export default function GoogleLogin() {
       localStorage.setItem('user', JSON.stringify(backendUser));
       localStorage.setItem('token', appJwt);
       setUser(backendUser);
-      navigate('/workspace');
+      navigate('/platform');
     } catch (err) {
       setError(err.message);
       setUser(null);

--- a/src/components/LectureHall.jsx
+++ b/src/components/LectureHall.jsx
@@ -49,7 +49,7 @@ export default function LectureHall({ theme }) {
   }, [stop]);
 
   const handleBack = () => {
-    navigate('/workspace');
+    navigate('/platform');
   };
 
   return (

--- a/src/components/WorkspaceLanding.jsx
+++ b/src/components/WorkspaceLanding.jsx
@@ -25,11 +25,12 @@ export default function WorkspaceLanding({ theme }) {
 
   const handleSubmit = (e) => {
     e.preventDefault();
-    if (isValidYouTubeUrl(url)) {
+    const trimmed = url.trim();
+    if (isValidYouTubeUrl(trimmed)) {
       setError('');
       console.log('Starting recording');
       start();
-      navigate(`/workspace/lecturehall?video=${encodeURIComponent(url)}`);
+      navigate(`/platform/lecturehall?video=${encodeURIComponent(trimmed)}`);
     } else {
       setError('Please enter a valid YouTube URL');
     }

--- a/src/components/WorkspaceNavbar.jsx
+++ b/src/components/WorkspaceNavbar.jsx
@@ -29,15 +29,15 @@ export default function WorkspaceNavbar({ theme, toggleTheme }) {
 
   return (
     <header className={`flex items-center justify-between px-4 py-3 border-b ${cfg.headerBorder} ${cfg.headerBg}`}> 
-      <Link to="/workspace" className="flex items-center gap-2 font-semibold">
+      <Link to="/platform" className="flex items-center gap-2 font-semibold">
         <BookOpen size={20} className={cfg.icon} />
         <span>EduNote</span>
       </Link>
       <nav className="flex items-center gap-4 text-sm">
-        <NavLink to="/workspace/library" className={({isActive}) => isActive ? 'font-semibold' : cfg.navLink }>
+        <NavLink to="/platform/library" className={({isActive}) => isActive ? 'font-semibold' : cfg.navLink }>
           Library
         </NavLink>
-        <NavLink to="/workspace/lecturehall" className={({isActive}) => isActive ? 'font-semibold' : cfg.navLink }>
+        <NavLink to="/platform/lecturehall" className={({isActive}) => isActive ? 'font-semibold' : cfg.navLink }>
           Lecture Hall
         </NavLink>
       </nav>


### PR DESCRIPTION
## Summary
- trim whitespace from pasted YouTube URLs so pressing **Enter** works
- rename `/workspace` route to `/platform` throughout the app

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_688b7f7ded6483209206d9b43f2d9f7d