### PR TITLE
Remove light/dark themes and standardize look

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -25,7 +25,7 @@
 //   );
 // }
 
-import React, { useState } from 'react';
+import React from 'react';
 import { BrowserRouter, Routes, Route, Navigate, useLocation } from 'react-router-dom';
 
 import Navbar from './components/Navbar';
@@ -42,18 +42,14 @@ import ErrorPage from './components/ErrorPage';
 import {landingContent} from './components/landingContent'; 
 
 export default function App() {
-  const [theme, setTheme] = useState('light');
-  const toggleTheme = () =>
-    setTheme((prev) => (prev === 'light' ? 'dark' : 'light'));
-
   return (
     <BrowserRouter>
-      <AppRoutes theme={theme} toggleTheme={toggleTheme} />
+      <AppRoutes />
     </BrowserRouter>
   );
 }
 
-function AppRoutes({ theme, toggleTheme }) {
+function AppRoutes() {
   const isLoggedIn = () => Boolean(localStorage.getItem('token'));
   const { navigation } = landingContent;
   const location = useLocation();
@@ -61,13 +57,7 @@ function AppRoutes({ theme, toggleTheme }) {
 
   return (
     <>
-      {!isWorkspace && (
-        <Navbar
-          theme={theme}
-          toggleTheme={toggleTheme}
-          navigation={navigation}
-        />
-      )}
+      {!isWorkspace && <Navbar navigation={navigation} />}
       <Routes>
         <Route
           path="/"
@@ -75,7 +65,7 @@ function AppRoutes({ theme, toggleTheme }) {
             isLoggedIn() ? (
               <Navigate to="/platform" replace />
             ) : (
-              <LandingPage theme={theme} />
+              <LandingPage />
             )
           }
         />
@@ -87,7 +77,7 @@ function AppRoutes({ theme, toggleTheme }) {
         />
         <Route
           path="platform/*"
-          element={<Workspace theme={theme} toggleTheme={toggleTheme} />}
+          element={<Workspace />}
         />
         <Route path="error" element={<ErrorPage />} />
         <Route path="privacy" element={<PrivacyPolicy />} />

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -117,8 +117,8 @@ import React from 'react';
 import * as Icons from 'lucide-react';
 import themeConfig from './themeConfig';
 
-const Footer = ({ footer, theme = 'light' }) => {
-  const cfg = themeConfig[theme];
+const Footer = ({ footer }) => {
+  const cfg = themeConfig.website;
 
   return (
     <footer

--- a/src/components/LandingPage.jsx
+++ b/src/components/LandingPage.jsx
@@ -7,12 +7,12 @@ import themeConfig from './themeConfig';
 import { PlayCircle, Layers3, MonitorPlay, Share2, MoveUpRight } from 'lucide-react';
 
 // Frosted-glass card
-const FrostCard = ({ children, theme, className = '' }) => (
-  <div className={`relative rounded-3xl shadow-lg backdrop-blur-xl backdrop-saturate-150 transition ${themeConfig[theme].cardBg} ${className}`}> {children} </div>
+const FrostCard = ({ children, className = '' }) => (
+  <div className={`relative rounded-3xl shadow-lg backdrop-blur-xl backdrop-saturate-150 transition ${themeConfig.website.cardBg} ${className}`}> {children} </div>
 );
 
-const LandingPage = ({ theme }) => {
-  const cfg = themeConfig[theme];
+const LandingPage = () => {
+  const cfg = themeConfig.website;
   const { hero, howItWorks, pricing, footer } = landingContent;
 
   return (
@@ -30,7 +30,7 @@ const LandingPage = ({ theme }) => {
         <div className="mt-10 flex flex-col sm:flex-row gap-4 justify-center">
           <button className={`px-8 py-4 rounded-lg font-semibold shadow-xl transition ${cfg.primaryBtn}`}>{hero.primaryCTA}</button>
           <button className={`flex gap-2 items-center px-8 py-4 rounded-lg transition ${cfg.secondaryBtn}`}>
-            <PlayCircle size={20} className={theme === 'light' ? 'text-emerald-600' : ''} /> {hero.secondaryCTA}
+            <PlayCircle size={20} className="text-emerald-600" /> {hero.secondaryCTA}
           </button>
         </div>
         {hero.statsText && <p className={`mt-4 ${cfg.statText}`}>{hero.statsText}</p>}
@@ -44,7 +44,7 @@ const LandingPage = ({ theme }) => {
           {howItWorks.steps.map(({ step, title, description }, i) => {
             const Icon = [Layers3, MonitorPlay, Share2][i] || Layers3;
             return (
-              <FrostCard key={step} theme={theme} className="p-8">
+              <FrostCard key={step} className="p-8">
                 <div className="flex items-baseline gap-2 text-sm font-semibold mb-2"><span className={cfg.primaryBtn.split(' ')[0]}>{step}</span></div>
                 <Icon size={32} className="mb-6" />
                 <h3 className="text-xl font-semibold mb-3">{title}</h3>
@@ -56,7 +56,7 @@ const LandingPage = ({ theme }) => {
       </section>
 
       {/* SPLIT DEMO */}
-      <section className={`relative backdrop-blur-md py-24 ${theme === 'light' ? 'bg-white/50' : 'bg-white/5'}`}>
+      <section className="relative backdrop-blur-md py-24 bg-white/50">
         <div className="max-w-6xl mx-auto grid md:grid-cols-2 gap-12 px-6 items-center">
           <motion.div whileHover={{ scale: 1.03 }} className="rounded-3xl overflow-hidden shadow-xl ring-1 ring-white/10"><video autoPlay muted loop playsInline src="https://cdn.edunote.ai/demo-trim.mp4" className="w-full h-full object-cover" /></motion.div>
           <div><h2 className="text-3xl font-bold mb-6">See your notes evolve in real time.</h2><ul className="space-y-4"><li className="flex gap-3 items-start"><Layers3 className="mt-1" /> AI detects headings & converts lists automatically.</li><li className="flex gap-3 items-start"><MonitorPlay className="mt-1" /> Timestamp links let you jump back to exact moments.</li><li className="flex gap-3 items-start"><Share2 className="mt-1" /> Export to Notion, Obsidian or markdown in one click.</li></ul></div>
@@ -64,13 +64,10 @@ const LandingPage = ({ theme }) => {
       </section>
 
       {/* PRICING */}
-      <section id="pricing" className="px-6 py-28"><h2 className="text-center text-4xl font-bold mb-4">{pricing.title}</h2><p className={`text-center mb-12 text-lg ${cfg.text}`}>{pricing.subtitle}</p><div className="grid max-w-4xl mx-auto md:grid-cols-3 gap-10">{pricing.plans.map(plan => (<FrostCard key={plan.name} theme={theme} className="p-10"><h3 className="text-2xl font-semibold mb-2">{plan.name}</h3><p className="text-4xl font-bold mb-6">{plan.price} <span className="text-lg font-normal">/{plan.period}</span></p><ul className="space-y-3 mb-8">{plan.features.map(f => (<li key={f} className="flex gap-2 items-start"><MoveUpRight size={18} className="mt-1" />{f}</li>))}</ul><button className={`w-full rounded-full py-3 font-semibold transition ${plan.popular ? cfg.primaryBtn : cfg.secondaryBtn}`}>{plan.cta}</button></FrostCard>))}</div></section>
+      <section id="pricing" className="px-6 py-28"><h2 className="text-center text-4xl font-bold mb-4">{pricing.title}</h2><p className={`text-center mb-12 text-lg ${cfg.text}`}>{pricing.subtitle}</p><div className="grid max-w-4xl mx-auto md:grid-cols-3 gap-10">{pricing.plans.map(plan => (<FrostCard key={plan.name} className="p-10"><h3 className="text-2xl font-semibold mb-2">{plan.name}</h3><p className="text-4xl font-bold mb-6">{plan.price} <span className="text-lg font-normal">/{plan.period}</span></p><ul className="space-y-3 mb-8">{plan.features.map(f => (<li key={f} className="flex gap-2 items-start"><MoveUpRight size={18} className="mt-1" />{f}</li>))}</ul><button className={`w-full rounded-full py-3 font-semibold transition ${plan.popular ? cfg.primaryBtn : cfg.secondaryBtn}`}>{plan.cta}</button></FrostCard>))}</div></section>
 
       {/* <Footer footer={footer} /> */}
-      <Footer
-        footer={footer}
-        theme={theme}
-      />
+      <Footer footer={footer} />
     </div>
   );
 };

--- a/src/components/LectureHall.jsx
+++ b/src/components/LectureHall.jsx
@@ -16,12 +16,12 @@ function extractId(url) {
   }
 }
 
-export default function LectureHall({ theme }) {
+export default function LectureHall() {
   const [params] = useSearchParams();
   const navigate = useNavigate();
   const videoUrl = params.get('video');
   const videoId = extractId(videoUrl);
-  const cfg = themeConfig[theme];
+  const cfg = themeConfig.website;
   const { stop } = useAudioRecorder();
   const [activePanel, setActivePanel] = useState(null);
   const iframeRef = useRef(null);
@@ -95,7 +95,7 @@ export default function LectureHall({ theme }) {
           </div>
         </div>
         <aside
-          className={`fixed top-0 right-0 w-96 max-w-full h-full shadow-xl transition-transform transform ${activePanel ? 'translate-x-0' : 'translate-x-full'} ${theme === 'light' ? 'bg-white' : 'bg-[#0c1424]'}`}
+          className={`fixed top-0 right-0 w-96 max-w-full h-full shadow-xl transition-transform transform ${activePanel ? 'translate-x-0' : 'translate-x-full'} bg-white`}
         >
           <div className="flex items-center justify-between p-4 border-b border-slate-200/50">
             <h2 className="font-semibold capitalize">{activePanel ? activePanel : ''}</h2>

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -142,17 +142,15 @@ import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import {
   Sparkles,
-  Sun,
-  Moon,
   ChevronDown,
   Menu,
 } from 'lucide-react';
 
 import themeConfig from './themeConfig';
 
-const Navbar = ({ theme, toggleTheme, navigation }) => {
+const Navbar = ({ navigation }) => {
   const [isOpen, setIsOpen] = useState(false);
-  const cfg = themeConfig[theme];
+  const cfg = themeConfig.website;
 
   return (
     <header
@@ -204,13 +202,6 @@ const Navbar = ({ theme, toggleTheme, navigation }) => {
             aria-label="Toggle menu"
           >
             <Menu size={24} />
-          </button>
-          <button
-            onClick={toggleTheme}
-            className={`p-2 rounded-full transition ${cfg.icon}`}
-            aria-label="Toggle theme"
-          >
-            {theme === 'light' ? <Moon size={20} /> : <Sun size={20} />}
           </button>
           <Link
             to="/login"

--- a/src/components/PrivacyPolicy.jsx
+++ b/src/components/PrivacyPolicy.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { motion } from 'framer-motion';
 import { Shield } from 'lucide-react';
-import themeConfig from './themeConfig'; 
+import themeConfig from './themeConfig';
 import Navbar from './Navbar';
 
-const PrivacyPolicy = ({ theme = 'light' }) => {
-  const cfg = themeConfig[theme];
+const PrivacyPolicy = () => {
+  const cfg = themeConfig.website;
 
   return (
     <>

--- a/src/components/Workspace.jsx
+++ b/src/components/Workspace.jsx
@@ -6,19 +6,19 @@ import Library from './Library';
 import LectureHall from './LectureHall';
 import WorkspaceLanding from './WorkspaceLanding';
 
-export default function Workspace({ theme, toggleTheme }) {
-  const cfg = themeConfig[theme];
+export default function Workspace() {
+  const cfg = themeConfig.website;
   return (
     <div className={cfg.root}>
-      <WorkspaceNavbar theme={theme} toggleTheme={toggleTheme} />
+      <WorkspaceNavbar />
       <main className="min-h-screen px-4 py-6">
         <Routes>
-          <Route index element={<WorkspaceLanding theme={theme} />} />
+          <Route index element={<WorkspaceLanding />} />
           <Route path="library" element={<Library />} />
-          <Route path="lecturehall" element={<LectureHall theme={theme} />} />
+          <Route path="lecturehall" element={<LectureHall />} />
         </Routes>
       </main>
-      <WorkspaceFooter theme={theme} />
+      <WorkspaceFooter />
     </div>
   );
 }

--- a/src/components/WorkspaceFooter.jsx
+++ b/src/components/WorkspaceFooter.jsx
@@ -1,7 +1,7 @@
 import themeConfig from './themeConfig';
 
-export default function WorkspaceFooter({ theme }) {
-  const cfg = themeConfig[theme];
+export default function WorkspaceFooter() {
+  const cfg = themeConfig.website;
   return (
     <footer className={`text-center py-4 ${cfg.cardBg} ${cfg.borderTop}`}> 
       <p className={cfg.text}>© 2025 EduNote</p>

--- a/src/components/WorkspaceLanding.jsx
+++ b/src/components/WorkspaceLanding.jsx
@@ -16,11 +16,11 @@ function isValidYouTubeUrl(url) {
   }
 }
 
-export default function WorkspaceLanding({ theme }) {
+export default function WorkspaceLanding() {
   const [url, setUrl] = useState('');
   const [error, setError] = useState('');
   const navigate = useNavigate();
-  const cfg = themeConfig[theme];
+  const cfg = themeConfig.website;
   const { start } = useAudioRecorder();
 
   const handleSubmit = (e) => {
@@ -49,7 +49,7 @@ export default function WorkspaceLanding({ theme }) {
           value={url}
           onChange={(e) => setUrl(e.target.value)}
           autoFocus
-          className="w-full px-4 py-3 rounded-lg focus:outline-none bg-transparent border border-slate-300 dark:border-white/20"
+          className="w-full px-4 py-3 rounded-lg focus:outline-none bg-transparent border border-slate-300"
         />
         {error && (
           <p className="text-sm text-red-500 flex items-center gap-1">

--- a/src/components/WorkspaceNavbar.jsx
+++ b/src/components/WorkspaceNavbar.jsx
@@ -1,10 +1,10 @@
 import { Link, NavLink, useNavigate } from 'react-router-dom';
-import { Sun, Moon, BookOpen, GraduationCap, UserCircle, LogOut, Mic } from 'lucide-react';
+import { BookOpen, GraduationCap, UserCircle, LogOut, Mic } from 'lucide-react';
 import themeConfig from './themeConfig';
 import { useAudioRecorder } from './AudioRecorderContext.jsx';
 
-export default function WorkspaceNavbar({ theme, toggleTheme }) {
-  const cfg = themeConfig[theme];
+export default function WorkspaceNavbar() {
+  const cfg = themeConfig.website;
   const { isRecording } = useAudioRecorder();
   const navigate = useNavigate();
   let username = 'User';
@@ -42,9 +42,6 @@ export default function WorkspaceNavbar({ theme, toggleTheme }) {
         </NavLink>
       </nav>
       <div className="flex items-center gap-4">
-        <button onClick={toggleTheme} aria-label="Toggle theme" className={cfg.icon}>
-          {theme === 'light' ? <Moon size={18}/> : <Sun size={18}/>}
-        </button>
         {isRecording && <Mic size={18} className="text-red-500" />}
         <div className="flex items-center gap-2">
           <UserCircle size={20} className={cfg.icon} />

--- a/src/components/themeConfig.js
+++ b/src/components/themeConfig.js
@@ -1,7 +1,6 @@
 export default {
-  light: {
+  website: {
     root: 'min-h-screen bg-gradient-to-br from-white via-slate-50 to-emerald-50/50 text-slate-900 selection:bg-emerald-300/30',
-    // headerBg: 'bg-white/70 ring-slate-200/50 text-slate-900',
     navLink: 'text-slate-700 hover:text-emerald-600',
     primaryBtn: 'bg-emerald-500 hover:bg-emerald-600 text-white',
     secondaryBtn: 'border border-slate-300 hover:border-emerald-500 bg-white/30 text-slate-900',
@@ -12,19 +11,5 @@ export default {
     headerBg: 'bg-white/70 backdrop-blur-lg shadow-md',
     headerBorder: 'border-slate-200/50',
     borderTop: 'border-t border-slate-200/50',
-  },
-  dark: {
-    root: 'min-h-screen bg-gradient-to-br from-[#10141f] via-[#0c1424] to-[#05080f] text-white selection:bg-emerald-400/30',
-    //headerBg: 'bg-white/5 ring-white/10 text-white',
-    navLink: 'text-white hover:text-emerald-400',
-    primaryBtn: 'bg-emerald-400 hover:bg-emerald-300 text-slate-900',
-    secondaryBtn: 'border border-white/20 hover:border-emerald-400 backdrop-blur-sm text-white',
-    cardBg: 'bg-white/10 ring-white/10',
-    text: 'text-slate-300',
-    statText: 'text-sm text-slate-300',
-    icon: 'text-white hover:text-emerald-400',
-    headerBg: 'bg-[#0c1424]/70 backdrop-blur-lg shadow-md',
-    headerBorder: 'border-white/10',
-    borderTop: 'border-t border-white/10',
   },
 };


### PR DESCRIPTION
## Summary
- drop theme toggle support
- implement single `website` theme
- refactor platform UI to use new theme
- remove dark theme specific classes

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_688bd97f015c832086a5f094f99e91bb