### PR TITLE
Add dropdown user menu

### DIFF
--- a/src/components/WorkspaceNavbar.jsx
+++ b/src/components/WorkspaceNavbar.jsx
@@ -1,12 +1,34 @@
 import { Link, NavLink, useNavigate } from 'react-router-dom';
-import { Sun, Moon, BookOpen, GraduationCap, UserCircle, LogOut, Mic } from 'lucide-react';
+import {
+  Sun,
+  Moon,
+  BookOpen,
+  UserCircle,
+  LogOut,
+  Mic,
+  BarChart2,
+  User,
+} from 'lucide-react';
 import themeConfig from './themeConfig';
 import { useAudioRecorder } from './AudioRecorderContext.jsx';
+import { useState, useEffect, useRef } from 'react';
 
 export default function WorkspaceNavbar({ theme, toggleTheme }) {
   const cfg = themeConfig[theme];
   const { isRecording } = useAudioRecorder();
   const navigate = useNavigate();
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef(null);
+
+  useEffect(() => {
+    function handleClickOutside(e) {
+      if (menuRef.current && !menuRef.current.contains(e.target)) {
+        setMenuOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
   let username = 'User';
   const storedUser = localStorage.getItem('user');
   if (storedUser) {
@@ -41,18 +63,48 @@ export default function WorkspaceNavbar({ theme, toggleTheme }) {
           Lecture Hall
         </NavLink>
       </nav>
-      <div className="flex items-center gap-4">
+      <div className="flex items-center gap-4 relative" ref={menuRef}>
         <button onClick={toggleTheme} aria-label="Toggle theme" className={cfg.icon}>
           {theme === 'light' ? <Moon size={18}/> : <Sun size={18}/>}
         </button>
         {isRecording && <Mic size={18} className="text-red-500" />}
-        <div className="flex items-center gap-2">
+        <button
+          onClick={() => setMenuOpen((o) => !o)}
+          aria-label="User menu"
+          className="flex items-center gap-2"
+        >
           <UserCircle size={20} className={cfg.icon} />
           <span className="text-sm">{username}</span>
-          <button onClick={handleLogout} aria-label="Logout" className={cfg.icon}>
-            <LogOut size={18} />
-          </button>
-        </div>
+        </button>
+        {menuOpen && (
+          <div
+            className={`absolute right-0 mt-2 w-40 rounded-md shadow-lg z-10 ${cfg.cardBg}`}
+          >
+            <NavLink
+              to="/platform/stats"
+              className="flex items-center gap-2 px-3 py-2 hover:bg-gray-100 dark:hover:bg-white/10"
+              onClick={() => setMenuOpen(false)}
+            >
+              <BarChart2 size={16} /> Stats
+            </NavLink>
+            <NavLink
+              to="/platform/profile"
+              className="flex items-center gap-2 px-3 py-2 hover:bg-gray-100 dark:hover:bg-white/10"
+              onClick={() => setMenuOpen(false)}
+            >
+              <User size={16} /> Profile
+            </NavLink>
+            <button
+              onClick={() => {
+                setMenuOpen(false);
+                handleLogout();
+              }}
+              className="flex w-full items-center gap-2 px-3 py-2 text-left hover:bg-gray-100 dark:hover:bg-white/10"
+            >
+              <LogOut size={16} /> Logout
+            </button>
+          </div>
+        )}
       </div>
     </header>
   );


### PR DESCRIPTION
## Summary
- add lucide BarChart2 and User icons and convert workspace navbar to dropdown menu
- click user name to show Stats, Profile and Logout options

## Testing
- `npm run lint` *(fails: React prop-types, unused vars)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688cb5bee0648320a3bddfc8b62208e3