### PR TITLE
Add user dropdown menu

### DIFF
--- a/src/components/Platform.jsx
+++ b/src/components/Platform.jsx
@@ -4,6 +4,8 @@ import PlatformNavbar from './PlatformNavbar';
 import Library from './Library';
 import LectureHall from './LectureHall';
 import PlatformLanding from './PlatformLanding';
+import Stats from './Stats';
+import Profile from './Profile';
 
 export default function Platform() {
   const cfg = themeConfig.app;
@@ -15,6 +17,8 @@ export default function Platform() {
           <Route index element={<PlatformLanding/>} />
           <Route path="library" element={<Library />} />
           <Route path="lecturehall" element={<LectureHall  />} />
+          <Route path="stats" element={<Stats />} />
+          <Route path="profile" element={<Profile />} />
         </Routes>
       </main>
     </div>

--- a/src/components/PlatformNavbar.jsx
+++ b/src/components/PlatformNavbar.jsx
@@ -2,7 +2,21 @@
 
 import { Link, NavLink, useNavigate } from 'react-router-dom';
 import { useState, useEffect } from 'react';
-import { Video, Book, BookOpen, UserCircle, LogOut, Mic, Download, Shield, HelpCircle, Info, ChevronDown } from 'lucide-react'; // Added icons for dropdown items and ChevronDown
+import {
+  Video,
+  Book,
+  BookOpen,
+  UserCircle,
+  LogOut,
+  Mic,
+  Download,
+  Shield,
+  HelpCircle,
+  Info,
+  ChevronDown,
+  BarChart2,
+  User
+} from 'lucide-react';
 import themeConfig from './themeConfig';
 import { useAudioRecorder } from './AudioRecorderContext.jsx';
 
@@ -11,10 +25,10 @@ export default function PlatformNavbar() {
   const [scrolled, setScrolled] = useState(false);
   const { isRecording } = useAudioRecorder();
   const navigate = useNavigate();
-  const [isResourcesOpen, setIsResourcesOpen] = useState(false); // State for dropdown toggle
+  const [isResourcesOpen, setIsResourcesOpen] = useState(false); // State for resources dropdown toggle
+  const [isUserOpen, setIsUserOpen] = useState(false); // State for user dropdown
   let username = 'User';
   const storedUser = localStorage.getItem('user');
-  console.log(storedUser)
   if (storedUser) {
     try {
       const userObj = JSON.parse(storedUser);
@@ -121,13 +135,47 @@ export default function PlatformNavbar() {
       </nav>
       <div className="flex items-center gap-4">
         {isRecording && <Mic size={18} className="text-red-500" />}
-        <div className="flex items-center gap-2">
-          <UserCircle size={20} className={cfg.icon} />
-          <span className="text-sm">{username}</span>
-          <button onClick={handleLogout} aria-label="Logout" className={`${cfg.icon} flex items-center gap-2`}>
-            <LogOut size={18} />
-            <span>Logout</span>
+        <div className="relative">
+          <button
+            onClick={() => setIsUserOpen(!isUserOpen)}
+            className="flex items-center gap-2"
+            aria-haspopup="true"
+            aria-expanded={isUserOpen}
+          >
+            <UserCircle size={20} className={cfg.icon} />
+            <span className="text-sm">{username}</span>
+            <ChevronDown className="w-4 h-4" />
           </button>
+          {isUserOpen && (
+            <div className="absolute right-0 mt-2 w-40 bg-white shadow-lg rounded-md py-2 z-50">
+              <NavLink
+                to="/platform/stats"
+                className="flex items-center gap-2 px-4 py-2 hover:bg-gray-100"
+                onClick={() => setIsUserOpen(false)}
+              >
+                <BarChart2 className="w-4 h-4" />
+                Stats
+              </NavLink>
+              <NavLink
+                to="/platform/profile"
+                className="flex items-center gap-2 px-4 py-2 hover:bg-gray-100"
+                onClick={() => setIsUserOpen(false)}
+              >
+                <User className="w-4 h-4" />
+                Profile
+              </NavLink>
+              <button
+                onClick={() => {
+                  setIsUserOpen(false);
+                  handleLogout();
+                }}
+                className="flex w-full items-center gap-2 px-4 py-2 hover:bg-gray-100 text-left"
+              >
+                <LogOut className="w-4 h-4" />
+                Logout
+              </button>
+            </div>
+          )}
         </div>
       </div>
     </header>

--- a/src/components/Profile.jsx
+++ b/src/components/Profile.jsx
@@ -1,0 +1,8 @@
+export default function Profile() {
+  return (
+    <div className="p-6">
+      <h2 className="text-2xl font-semibold mb-4">Profile</h2>
+      <p>Manage your profile information here.</p>
+    </div>
+  );
+}

--- a/src/components/Stats.jsx
+++ b/src/components/Stats.jsx
@@ -1,0 +1,8 @@
+export default function Stats() {
+  return (
+    <div className="p-6">
+      <h2 className="text-2xl font-semibold mb-4">Stats</h2>
+      <p>Your statistics will appear here.</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add placeholder components for stats and profile pages
- add routes for new pages
- replace profile/logout display with dropdown menu
- link stats, profile, and logout options from navbar

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688cb8f052488320ae7f69ec44e4e863