### PR TITLE
Adjust lecture hall video layout

### DIFF
--- a/src/components/LectureHall.jsx
+++ b/src/components/LectureHall.jsx
@@ -48,17 +48,21 @@ export default function LectureHall() {
   }, [stop]);
 
   return (
-    <div className="relative flex flex-col h-full overflow-hidden p-6 pt-14 bg-slate-50 text-slate-900 font-fraunces selection:bg-emerald-300/30">
+    <div
+      className={`relative h-full overflow-hidden p-6 pt-14 bg-slate-50 text-slate-900 font-fraunces selection:bg-emerald-300/30 ${
+        activePanel ? 'pr-[30rem]' : ''
+      }`}
+    >
       {videoId ? (
         <>
-          <div className="flex-1 space-y-8 max-w-6xl mx-auto flex flex-col justify-center">
+          <div className="h-full">
             {/* Updated video container with app-specific styling */}
-            <div className={cfg.videoContainer}>
+            <div className={`${cfg.videoContainer} h-full`}>
               <iframe
                 ref={iframeRef}
                 src={`https://www.youtube.com/embed/${videoId}?enablejsapi=1`}
                 title="YouTube video"
-                className={cfg.videoPlayer}
+                className={`${cfg.videoPlayer} h-full`}
                 allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
                 allowFullScreen
               />

--- a/src/components/themeConfig.js
+++ b/src/components/themeConfig.js
@@ -53,8 +53,8 @@ export default {
     breadcrumb: 'text-sm text-slate-500 hover:text-slate-700',
     
     // Video Player Components
-    videoContainer: 'bg-black rounded-lg shadow-xl overflow-hidden ring-1 ring-slate-200/50',
-    videoPlayer: 'w-full aspect-video bg-black rounded-lg',
+    videoContainer: 'w-full h-full bg-black rounded-lg shadow-xl overflow-hidden ring-1 ring-slate-200/50',
+    videoPlayer: 'w-full h-full bg-black',
     videoControls: 'bg-black/80 backdrop-blur-sm',
     videoOverlay: 'bg-black/50 hover:bg-black/30 transition-all duration-300',
     videoProgress: 'bg-emerald-600 h-1 transition-all duration-100',


### PR DESCRIPTION
## Summary
- make the lecture iframe use the entire lecture hall
- reserve space when sidebar is open

## Testing
- `npm run lint` *(fails: `no-unused-vars` in multiple files)*

------
https://chatgpt.com/codex/tasks/task_e_688cd84ee6308320ae2861180509227b