### PR TITLE
Adjust lecture hall layout spacing

### DIFF
--- a/src/components/LectureHall.jsx
+++ b/src/components/LectureHall.jsx
@@ -50,7 +50,7 @@ export default function LectureHall() {
 
   return (
     <div
-      className={`relative h-full overflow-hidden p-6 pt-14 bg-slate-50 text-slate-900 font-fraunces selection:bg-emerald-300/30 ${
+      className={`relative h-full overflow-hidden p-2 pt-2 bg-slate-50 text-slate-900 font-fraunces selection:bg-emerald-300/30 ${
         activePanel ? 'pr-[30rem]' : ''
       }`}
     >

--- a/src/components/Platform.jsx
+++ b/src/components/Platform.jsx
@@ -1,4 +1,4 @@
-import { Routes, Route } from 'react-router-dom';
+import { Routes, Route, useLocation } from 'react-router-dom';
 import themeConfig from './themeConfig';
 import PlatformNavbar from './PlatformNavbar';
 import Library from './Library';
@@ -10,11 +10,13 @@ import Profile from './Profile';
 
 export default function Platform() {
   const cfg = themeConfig.app;
+  const location = useLocation();
+  const isLectureHall = location.pathname.startsWith('/platform/lecturehall');
   return (
     <LectureHallProvider>
       <div className={`${cfg.root} h-screen flex flex-col overflow-hidden`}>
         <PlatformNavbar />
-        <main className="flex-1 overflow-hidden px-4 py-6">
+        <main className={`flex-1 overflow-hidden ${isLectureHall ? 'p-2 pt-2' : 'px-4 py-6'}`}>
           <Routes>
             <Route index element={<PlatformLanding/>} />
             <Route path="library" element={<Library />} />


### PR DESCRIPTION
## Summary
- reduce lecture hall padding so the iframe fills more space
- make Platform main padding smaller when viewing the lecture hall

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_688ce543ee60832083aa47d6c2ec094b