### PR TITLE
Adjust lecture hall navbar spacing

### DIFF
--- a/src/components/PlatformNavbar.jsx
+++ b/src/components/PlatformNavbar.jsx
@@ -99,7 +99,7 @@ export default function PlatformNavbar() {
               User Guide
             </NavLink>
           </div>
-          <div className="flex items-center gap-4 ml-auto">
+          <div className="flex items-center gap-4 ml-auto -mr-4 md:-mr-6">
             <button onClick={() => openPanel('doubt')} className={`${cfg.primaryBtn} flex items-center gap-1 px-3 py-2 text-sm`}>
               <HelpCircle className="w-4 h-4" />
               Ask Doubts


### PR DESCRIPTION
## Summary
- nudge lecture hall buttons slightly to the right with negative margin

## Testing
- `npm run lint` *(fails: various unused variable errors)*

------
https://chatgpt.com/codex/tasks/task_e_688ce577351c832083886061e12feee0