### PR TITLE
fix: stabilize pauseVideo handler

### DIFF
--- a/src/components/LectureHall.jsx
+++ b/src/components/LectureHall.jsx
@@ -1,5 +1,5 @@
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, useCallback } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import themeConfig from './themeConfig';
 import { useAudioRecorder } from './AudioRecorderContext.jsx';
@@ -34,19 +34,19 @@ export default function LectureHall() {
   const attemptedQuestions = [];
   const unattemptedQuestions = [];
 
-  const pauseVideo = () => {
+  const pauseVideo = useCallback(() => {
     if (iframeRef.current) {
       iframeRef.current.contentWindow.postMessage(
         '{"event":"command","func":"pauseVideo","args":""}',
         '*'
       );
     }
-  };
+  }, []);
 
 
   useEffect(() => {
     registerPause(pauseVideo);
-  }, [registerPause]);
+  }, [registerPause, pauseVideo]);
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
## Summary
- ensure `pauseVideo` is stable and registered with correct dependencies to avoid console warnings in Lecture Hall

## Testing
- `npx eslint src/components/LectureHall.jsx`
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 39 problems)*

------
https://chatgpt.com/codex/tasks/task_e_688dd072f0888320accb2f446de89886