### PR TITLE
Implement chat websocket handling

### DIFF
--- a/src/components/useChatWebSocket.js
+++ b/src/components/useChatWebSocket.js
@@ -1,0 +1,44 @@
+import { useEffect, useRef } from 'react';
+
+export function useChatWebSocket(tabId, { onMessage, onToken, onChatId } = {}) {
+  const wsRef = useRef(null);
+
+  useEffect(() => {
+    const params = new URLSearchParams({ tab_id: tabId });
+    const storedChatId = localStorage.getItem('chat_id');
+    if (storedChatId) {
+      params.append('chat_id', storedChatId);
+    }
+
+    const ws = new WebSocket(`ws://localhost:8000/ws/chat?${params.toString()}`);
+    wsRef.current = ws;
+
+    ws.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        if (data.chat_id) {
+          localStorage.setItem('chat_id', data.chat_id);
+          if (onChatId) onChatId(data.chat_id);
+        } else if (data.message !== undefined) {
+          if (onMessage) onMessage(data.message);
+        } else if (data.token !== undefined) {
+          if (onToken) onToken(data.token);
+        }
+      } catch (err) {
+        console.error('Invalid websocket message', err);
+      }
+    };
+
+    return () => {
+      ws.close();
+    };
+  }, [tabId, onMessage, onToken, onChatId]);
+
+  const sendMessage = (message) => {
+    if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) {
+      wsRef.current.send(JSON.stringify({ message }));
+    }
+  };
+
+  return { sendMessage };
+}


### PR DESCRIPTION
## Summary
- add ChatView hook to handle chat websocket connections
- stream server messages and tokens to chat list with per-tab tracking

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 70 problems (67 errors, 3 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_688f1e922e4c832f81046c9088fdb269