### PR TITLE
Send playback time with chat messages

### DIFF
--- a/src/components/ChatView.jsx
+++ b/src/components/ChatView.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import PropTypes from 'prop-types';
 import { ArrowRight } from 'lucide-react';
 import { useChatWebSocket } from './ChatWebSocket';
 
@@ -11,7 +12,7 @@ function getTabId() {
   return id;
 }
 
-export default function ChatView() {
+export default function ChatView({ getCurrentTime }) {
   const [messages, setMessages] = useState([]);
   const [input, setInput] = useState('');
 
@@ -32,6 +33,7 @@ export default function ChatView() {
         return updated;
       });
     },
+    getPlaybackTime: getCurrentTime,
   });
 
   const handleSend = () => {
@@ -93,3 +95,7 @@ export default function ChatView() {
     </div>
   );
 }
+
+ChatView.propTypes = {
+  getCurrentTime: PropTypes.func,
+};

--- a/src/components/ChatWebSocket.js
+++ b/src/components/ChatWebSocket.js
@@ -1,10 +1,17 @@
 import { useEffect, useRef } from 'react';
 
-export function useChatWebSocket(tabId, { onMessage, onToken, onChatId } = {}) {
+export function useChatWebSocket(
+  tabId,
+  { onMessage, onToken, onChatId, getPlaybackTime } = {}
+) {
   const wsRef = useRef(null);
 
   useEffect(() => {
     const params = new URLSearchParams({ tab_id: tabId });
+    if (getPlaybackTime) {
+      const time = Math.floor(getPlaybackTime());
+      params.append('playback_time', time);
+    }
     const storedChatId = localStorage.getItem('chatId');
     if (storedChatId) {
       params.append('chat_id', storedChatId);
@@ -32,11 +39,15 @@ export function useChatWebSocket(tabId, { onMessage, onToken, onChatId } = {}) {
     return () => {
       ws.close();
     };
-  }, [tabId, onMessage, onToken, onChatId]);
+  }, [tabId, onMessage, onToken, onChatId, getPlaybackTime]);
 
   const sendMessage = (message) => {
     if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) {
-      wsRef.current.send(JSON.stringify({ message }));
+      const payload = { message };
+      if (getPlaybackTime) {
+        payload.playback_time = Math.floor(getPlaybackTime());
+      }
+      wsRef.current.send(JSON.stringify(payload));
     }
   };
 

--- a/src/components/SidePanel.jsx
+++ b/src/components/SidePanel.jsx
@@ -1,9 +1,9 @@
-import React from 'react';
 import themeConfig from './themeConfig';
 import { X } from 'lucide-react';
 import ChatView from './ChatView';
+import PropTypes from 'prop-types';
 
-export default function SidePanel({ tab, onClose }) {
+export default function SidePanel({ tab, onClose, getCurrentTime }) {
   const cfg = themeConfig.app;
 
   const renderContent = () => {
@@ -11,7 +11,7 @@ export default function SidePanel({ tab, onClose }) {
       return <p className={cfg.cardSubheading}>Ask your doubt here</p>;
     }
     if (tab === 'Attempt Question') {
-      return <p className={cfg.cardSubheading}>Here's a question to try</p>;
+      return <p className={cfg.cardSubheading}>Here&apos;s a question to try</p>;
     }
     if (tab === 'Take Notes') {
       return <p className={cfg.cardSubheading}>Take your notes here</p>;
@@ -20,7 +20,7 @@ export default function SidePanel({ tab, onClose }) {
   };
 
   const renderUI = () => {
-    if (tab === 'Ask Doubt') return <ChatView />;
+    if (tab === 'Ask Doubt') return <ChatView getCurrentTime={getCurrentTime} />;
     return null;
   };
 
@@ -36,3 +36,9 @@ export default function SidePanel({ tab, onClose }) {
     </div>
   );
 }
+
+SidePanel.propTypes = {
+  tab: PropTypes.string,
+  onClose: PropTypes.func,
+  getCurrentTime: PropTypes.func,
+};

--- a/src/components/StudyRoom.jsx
+++ b/src/components/StudyRoom.jsx
@@ -28,7 +28,7 @@ export default function StudyRoom() {
   const [sidePanelTab, setSidePanelTab] = useState(null);
   const isSidePanelOpen = !!sidePanelTab;
 
-  const { iframeRef , pause} = useYouTubePlayer(videoId);
+  const { iframeRef, pause, getCurrentTime } = useYouTubePlayer(videoId);
 
   const showIframe = videoId && mode === 'play';
   
@@ -59,7 +59,11 @@ export default function StudyRoom() {
               allowFullScreen
             />
             {isSidePanelOpen && (
-              <SidePanel tab={sidePanelTab} onClose={() => setSidePanelTab(null)} />
+              <SidePanel
+                tab={sidePanelTab}
+                onClose={() => setSidePanelTab(null)}
+                getCurrentTime={getCurrentTime}
+              />
             )}
           </div>
         </>


### PR DESCRIPTION
## Summary
- Include current video playback time in WebSocket connection and outgoing messages.
- Wire StudyRoom's YouTube player timestamp through SidePanel and ChatView so chat can report playback time.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 72 problems across repository)*
- `npx eslint src/components/ChatWebSocket.js src/components/ChatView.jsx src/components/SidePanel.jsx src/components/StudyRoom.jsx`

------
https://chatgpt.com/codex/tasks/task_e_688f2693baac832f9b501b1e484567ad