### PR TITLE
Load saved chat messages

### DIFF
--- a/src/components/ChatView.jsx
+++ b/src/components/ChatView.jsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { ArrowRight } from 'lucide-react';
 import { useChatWebSocket } from './ChatWebSocket';
@@ -28,6 +28,29 @@ export default function ChatView({ getCurrentTime }) {
     },
     getPlaybackTime: getCurrentTime,
   });
+
+  useEffect(() => {
+    const chatId = localStorage.getItem('chatId');
+    const token = localStorage.getItem('token');
+    if (!chatId || !token) return;
+
+    fetch(`http://localhost:8000/messages/${chatId}`, {
+      headers: {
+        Authorization: token,
+      },
+    })
+      .then((res) => res.json())
+      .then((data) => {
+        const loaded = (data.messages || []).map((m) => ({
+          role: m.message_from === 'assistant' ? 'agent' : 'user',
+          text: m.text,
+        }));
+        setMessages(loaded);
+      })
+      .catch((err) => {
+        console.error('Failed to load messages', err);
+      });
+  }, []);
 
   const handleSend = () => {
     const trimmed = input.trim();


### PR DESCRIPTION
## Summary
- Send JWT token directly in Authorization header when loading stored chat history in ChatView

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 66 problems)*

------
https://chatgpt.com/codex/tasks/task_e_688fb1e9e8b8832f9301c08e7cbfe0ed