### PR TITLE
Generate questions in study room mode

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,7 +11,7 @@ import PlatformLanding from './components/PlatformLanding';
 import GoogleLogin from './components/LoginPage';
 import ErrorPage from './components/ErrorPage';
 import VerifyLearner from './components/VerifyLearner';
-import StudyRoom from './components/studyRoom';
+import StudyRoom from './components/StudyRoom.jsx';
 import Library from './components/Library';
 
 

--- a/src/components/QuestionContext.jsx
+++ b/src/components/QuestionContext.jsx
@@ -1,0 +1,17 @@
+import React, { createContext, useContext, useState } from 'react';
+
+const QuestionsContext = createContext({
+  questions: { mcq: [], fill: [], subjective: [] },
+  setQuestions: () => {},
+});
+
+export function QuestionsProvider({ children }) {
+  const [questions, setQuestions] = useState({ mcq: [], fill: [], subjective: [] });
+  return (
+    <QuestionsContext.Provider value={{ questions, setQuestions }}>
+      {children}
+    </QuestionsContext.Provider>
+  );
+}
+
+export const useQuestions = () => useContext(QuestionsContext);

--- a/src/components/QuestionView.jsx
+++ b/src/components/QuestionView.jsx
@@ -1,214 +1,22 @@
-// import React from 'react';
-// import themeConfig from './themeConfig';
-
-// const dummyQuestions = [
-//     // MCQ - 4 questions
-//     {
-//       id: 1,
-//       type: 'mcq',
-//       question: 'What is the capital of Japan?',
-//       options: ['Beijing', 'Seoul', 'Tokyo', 'Bangkok'],
-//     },
-//     {
-//       id: 2,
-//       type: 'mcq',
-//       question: 'Which planet is known as the Red Planet?',
-//       options: ['Earth', 'Mars', 'Jupiter', 'Venus'],
-//     },
-//     {
-//       id: 3,
-//       type: 'mcq',
-//       question: 'Which gas do plants absorb from the atmosphere?',
-//       options: ['Oxygen', 'Carbon Dioxide', 'Nitrogen', 'Helium'],
-//     },
-//     {
-//       id: 4,
-//       type: 'mcq',
-//       question: 'What is the largest ocean on Earth?',
-//       options: ['Atlantic', 'Indian', 'Arctic', 'Pacific'],
-//     },
-  
-//     // Fill in the blanks - 2 questions
-//     {
-//       id: 5,
-//       type: 'fill',
-//       question: 'Light travels at a speed of ____ km/s.',
-//     },
-//     {
-//       id: 6,
-//       type: 'fill',
-//       question: 'The square root of 144 is ____.',
-//     },
-  
-//     // Subjective - 3 questions
-//     {
-//       id: 7,
-//       type: 'subjective',
-//       question: 'Describe the process of photosynthesis.',
-//     },
-//     {
-//       id: 8,
-//       type: 'subjective',
-//       question: 'What are the main causes of climate change?',
-//     },
-//     {
-//       id: 9,
-//       type: 'subjective',
-//       question: 'Explain Newton\'s laws of motion.',
-//     },
-//   ];
-  
-
-// // 🔹 MCQ Component
-// function MCQQuestion({ question, theme }) {
-//   return (
-//     <div>
-//       <div className={`${theme.cardHeadingSecondary}`}>MCQ</div>
-//       <div className="mt-4 p-4 rounded-lg bg-gray-50 border border-gray-200">
-//         <p className="text-sm text-gray-700 mb-3">{question.question}</p>
-//         <ul className="space-y-2">
-//           {question.options.map((option, idx) => (
-//             <li key={idx} className="flex items-center space-x-2">
-//               <input type="radio" id={`${question.id}-${idx}`} name={`q-${question.id}`} />
-//               <label htmlFor={`${question.id}-${idx}`} className="text-sm">{option}</label>
-//             </li>
-//           ))}
-//         </ul>
-//       </div>
-//     </div>
-//   );
-// }
-
-// // 🔹 Fill in the Blank Component
-// function FillInTheBlank({ question, theme }) {
-//   return (
-//     <div >
-//       <div className={`${theme.cardHeadingSecondary}`}>Fill in the Blank</div>
-//       <div className="mt-4 p-4 rounded-lg bg-gray-50 border border-gray-200">
-//         <p className="text-sm text-gray-700 mb-3">{question.question}</p>
-//         <input
-//           type="text"
-//           className="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:border-cyan-600 focus:ring-2 focus:ring-cyan-600"
-//           placeholder="Your answer"
-//         />
-//       </div>
-//     </div>
-//   );
-// }
-
-// // 🔹 Subjective Component
-// function SubjectiveQuestion({ question, theme }) {
-//   return (
-//     <div >
-//       <div className={`${theme.cardHeadingSecondary}`}>Subjective</div>
-//       <div className="mt-4 p-4 rounded-lg bg-gray-50 border border-gray-200">
-//         <p className="text-sm text-gray-700 mb-3">{question.question}</p>
-//         <textarea
-//           rows={4}
-//           className="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:border-cyan-600 focus:ring-2 focus:ring-cyan-600"
-//           placeholder="Write your answer here"
-//         />
-//       </div>
-//     </div>
-//   );
-// }
-
-// export default function QuestionView() {
-//   const cfg = themeConfig;
-
-//   return (
-//     <div className="flex flex-col h-full p-4 space-y-6 overflow-y-auto">
-//       {dummyQuestions.map((q) => {
-//         if (q.type === 'mcq') return <MCQQuestion key={q.id} question={q} theme={cfg} />;
-//         if (q.type === 'fill') return <FillInTheBlank key={q.id} question={q} theme={cfg} />;
-//         if (q.type === 'subjective') return <SubjectiveQuestion key={q.id} question={q} theme={cfg} />;
-//         return null;
-//       })}
-//     </div>
-//   );
-// }
-
-
-import React from 'react';
 import themeConfig from './themeConfig';
+import { useQuestions } from './QuestionContext.jsx';
 
-const dummyQuestions = [
-  // MCQ - 4 questions
-  {
-    id: 1,
-    type: 'mcq',
-    question: 'What is the capital of Japan?',
-    options: ['Beijing', 'Seoul', 'Tokyo', 'Bangkok'],
-  },
-  {
-    id: 2,
-    type: 'mcq',
-    question: 'Which planet is known as the Red Planet?',
-    options: ['Earth', 'Mars', 'Jupiter', 'Venus'],
-  },
-  {
-    id: 3,
-    type: 'mcq',
-    question: 'Which gas do plants absorb from the atmosphere?',
-    options: ['Oxygen', 'Carbon Dioxide', 'Nitrogen', 'Helium'],
-  },
-  {
-    id: 4,
-    type: 'mcq',
-    question: 'What is the largest ocean on Earth?',
-    options: ['Atlantic', 'Indian', 'Arctic', 'Pacific'],
-  },
-
-  // Fill in the blanks - 2 questions
-  {
-    id: 5,
-    type: 'fill',
-    question: 'Light travels at a speed of ____ km/s.',
-  },
-  {
-    id: 6,
-    type: 'fill',
-    question: 'The square root of 144 is ____.',
-  },
-
-  // Subjective - 3 questions
-  {
-    id: 7,
-    type: 'subjective',
-    question: 'Describe the process of photosynthesis.',
-  },
-  {
-    id: 8,
-    type: 'subjective',
-    question: 'What are the main causes of climate change?',
-  },
-  {
-    id: 9,
-    type: 'subjective',
-    question: "Explain Newton's laws of motion.",
-  },
-];
-
-// 🔹 MCQ Component
-function MCQQuestion({ question, theme }) {
+function MCQQuestion({ question }) {
   return (
-    <div>
-      <div className="mt-4 p-4 rounded-lg bg-gray-50 border border-gray-200">
-        <p className="text-sm text-gray-700 mb-3">{question.question}</p>
-        <ul className="space-y-2">
-          {question.options.map((option, idx) => (
-            <li key={idx} className="flex items-center space-x-2">
-              <input type="radio" id={`${question.id}-${idx}`} name={`q-${question.id}`} />
-              <label htmlFor={`${question.id}-${idx}`} className="text-sm">{option}</label>
-            </li>
-          ))}
-        </ul>
-      </div>
+    <div className="mt-4 p-4 rounded-lg bg-gray-50 border border-gray-200">
+      <p className="text-sm text-gray-700 mb-3">{question.question}</p>
+      <ul className="space-y-2">
+        {(question.options || []).map((option, idx) => (
+          <li key={idx} className="flex items-center space-x-2">
+            <input type="radio" id={`mcq-${idx}`} name={`mcq-${question.id || 0}`} />
+            <label htmlFor={`mcq-${idx}`} className="text-sm">{option}</label>
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }
 
-// 🔹 Fill in the Blank Component
 function FillInTheBlank({ question }) {
   return (
     <div className="mt-4 p-4 rounded-lg bg-gray-50 border border-gray-200">
@@ -222,7 +30,6 @@ function FillInTheBlank({ question }) {
   );
 }
 
-// 🔹 Subjective Component
 function SubjectiveQuestion({ question }) {
   return (
     <div className="mt-4 p-4 rounded-lg bg-gray-50 border border-gray-200">
@@ -237,42 +44,35 @@ function SubjectiveQuestion({ question }) {
 }
 
 export default function QuestionView() {
-  const cfg = themeConfig;
-
-  const grouped = {
-    mcq: dummyQuestions.filter((q) => q.type === 'mcq'),
-    fill: dummyQuestions.filter((q) => q.type === 'fill'),
-    subjective: dummyQuestions.filter((q) => q.type === 'subjective'),
-  };
+  const cfg = themeConfig.app;
+  const { questions } = useQuestions();
+  const { mcq = [], fill = [], subjective = [] } = questions;
 
   return (
     <div className="flex flex-col h-full p-4 space-y-8 overflow-y-auto">
-      {/* MCQ Group */}
-      {grouped.mcq.length > 0 && (
+      {mcq.length > 0 && (
         <div>
           <div className={`${cfg.cardHeadingSecondary} mb-2`}>MCQ</div>
-          {grouped.mcq.map((q) => (
-            <MCQQuestion key={q.id} question={q} theme={cfg} />
+          {mcq.map((q, idx) => (
+            <MCQQuestion key={idx} question={q} />
           ))}
         </div>
       )}
 
-      {/* Fill in the Blank Group */}
-      {grouped.fill.length > 0 && (
+      {fill.length > 0 && (
         <div>
           <div className={`${cfg.cardHeadingSecondary} mb-2`}>Fill in the Blank</div>
-          {grouped.fill.map((q) => (
-            <FillInTheBlank key={q.id} question={q} />
+          {fill.map((q, idx) => (
+            <FillInTheBlank key={idx} question={q} />
           ))}
         </div>
       )}
 
-      {/* Subjective Group */}
-      {grouped.subjective.length > 0 && (
+      {subjective.length > 0 && (
         <div>
           <div className={`${cfg.cardHeadingSecondary} mb-2`}>Subjective</div>
-          {grouped.subjective.map((q) => (
-            <SubjectiveQuestion key={q.id} question={q} />
+          {subjective.map((q, idx) => (
+            <SubjectiveQuestion key={idx} question={q} />
           ))}
         </div>
       )}

--- a/src/components/StudyRoom.jsx
+++ b/src/components/StudyRoom.jsx
@@ -1,11 +1,12 @@
 import { useSearchParams } from 'react-router-dom';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useYouTubePlayer } from './useYouTubePlayer.js';
 import PlatformNavbar from './PlatformNavbar';
 import StudyRoomNavbar from './StudyRoomNavbar.jsx';
 import VideoLinkInputCard from './VideoLinkInputCard.jsx';
 import themeConfig from './themeConfig';
 import SidePanel from './SidePanel.jsx';
+import { QuestionsProvider, useQuestions } from './QuestionContext.jsx';
 
 function extractId(url) {
   try {
@@ -19,7 +20,7 @@ function extractId(url) {
   }
 }
 
-export default function StudyRoom() {
+function StudyRoomInner() {
   const [params] = useSearchParams();
   const videoUrl = params.get('video') || '';
   const videoId = extractId(videoUrl);
@@ -27,11 +28,46 @@ export default function StudyRoom() {
   const cfg = themeConfig.app;
   const [sidePanelTab, setSidePanelTab] = useState(null);
   const isSidePanelOpen = !!sidePanelTab;
+  const { setQuestions } = useQuestions();
 
   const { iframeRef, pause, getCurrentTime } = useYouTubePlayer(videoId);
 
+  useEffect(() => {
+    if (mode !== 'true') return;
+
+    const fetchQuestions = async () => {
+      const token = localStorage.getItem('token');
+      const tabId = localStorage.getItem('tabId');
+      if (!token || !tabId) return;
+      try {
+        const res = await fetch('http://localhost:8000/questions/create', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: token,
+          },
+          body: JSON.stringify({ tab_id: tabId }),
+        });
+        if (!res.ok) return;
+        const data = await res.json();
+        const q = data.questions || {};
+        setQuestions({
+          mcq: q.mcq_questions || [],
+          fill: q.fill_in_the_blanks || [],
+          subjective: q.subjective_questions || [],
+        });
+      } catch (err) {
+        console.error('Failed to fetch questions', err);
+      }
+    };
+
+    fetchQuestions();
+    const interval = setInterval(fetchQuestions, 30000);
+    return () => clearInterval(interval);
+  }, [mode, setQuestions]);
+
   const showIframe = videoId && mode === 'play';
-  
+
   return (
     <div className="w-full h-full flex flex-col font-fraunces">
       {!showIframe ? (
@@ -45,9 +81,9 @@ export default function StudyRoom() {
         <>
           <StudyRoomNavbar videoUrl={videoUrl}
             onTabSelect={(tab) => {
-            pause(); // 👈 Pause video before opening side panel
-            setSidePanelTab(tab);
-          }}
+              pause(); // 👈 Pause video before opening side panel
+              setSidePanelTab(tab);
+            }}
             selectedTab={sidePanelTab}/>
           <div className="flex flex-1 overflow-hidden"> {/* Main row: video + side panel */}
             <iframe
@@ -69,5 +105,13 @@ export default function StudyRoom() {
         </>
       )}
     </div>
+  );
+}
+
+export default function StudyRoom() {
+  return (
+    <QuestionsProvider>
+      <StudyRoomInner />
+    </QuestionsProvider>
   );
 }


### PR DESCRIPTION
## Summary
- add questions context to share MCQ, fill and subjective lists
- poll `/questions/create` when study room mode is true and update question list
- render questions from shared context instead of static data

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 75 problems)*

------
https://chatgpt.com/codex/tasks/task_e_688fd5b11c20832fb9b8356b62f84bdd