### PR TITLE
feat: block mobile access to platform pages

### DIFF
--- a/src/components/DesktopOnly.jsx
+++ b/src/components/DesktopOnly.jsx
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+
+export default function DesktopOnly({ children }) {
+  const [isMobile, setIsMobile] = useState(() => window.innerWidth < 768);
+
+  useEffect(() => {
+    const handleResize = () => {
+      setIsMobile(window.innerWidth < 768);
+    };
+
+    handleResize();
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  if (isMobile) {
+    return (
+      <div className="flex items-center justify-center min-h-screen p-4 text-center font-fraunces">
+        Elon AI is currently available on desktop. Please use a desktop to access this page.
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}
+

--- a/src/components/LandingPage.jsx
+++ b/src/components/LandingPage.jsx
@@ -6,6 +6,7 @@ import { landingContent  } from './landingContent';
 import { useNavigate } from 'react-router-dom';
 import Footer from './Footer';
 import Navbar from './Navbar';
+import DesktopOnly from './DesktopOnly';
 
 
 const CTAButtons = ({ center = false, showDownload = true }) => {
@@ -43,6 +44,7 @@ const LandingPage = () => {
 
 
   return (
+    <DesktopOnly>
     <div className="bg-white min-h-screen font-fraunces">
       <Navbar />
       <div
@@ -152,6 +154,7 @@ const LandingPage = () => {
     </div>
     <Footer />
     </div>
+    </DesktopOnly>
   );
 };
 

--- a/src/components/Library.jsx
+++ b/src/components/Library.jsx
@@ -3,6 +3,7 @@ import { getTabs } from '../services/tabService';
 import { useEffect, useState } from 'react';
 import { fetchQuestions } from '../services/questionService';
 import { useNavigate } from 'react-router-dom';
+import DesktopOnly from './DesktopOnly';
 
 
 function CompletionCircle({ percent }) {
@@ -97,6 +98,7 @@ export default function Library() {
   
 
   return (
+    <DesktopOnly>
     <div className="font-fraunces bg-white">
       <PlatformNavbar defaultTab="Library" />
       <div className="px-[100px] py-[60px]">
@@ -152,5 +154,6 @@ export default function Library() {
         </div>
       </div>
     </div>
+    </DesktopOnly>
   );
 }

--- a/src/components/LibraryDetail.jsx
+++ b/src/components/LibraryDetail.jsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import PlatformNavbar from './PlatformNavbar';
 import { fetchQuestions, submitQuestionAnswer } from '../services/questionService';
 import { SendHorizontal, CheckCircle, AlertCircle } from 'lucide-react';
+import DesktopOnly from './DesktopOnly';
 
 const getDifficultyColor = (level) => {
   if (level === 'easy') return 'bg-green-100 text-green-700';
@@ -228,6 +229,7 @@ export default function LibraryDetail() {
   };
 
   return (
+    <DesktopOnly>
     <div className="min-h-screen bg-white flex flex-col font-fraunces">
       <PlatformNavbar defaultTab="Library" />
 
@@ -318,5 +320,6 @@ export default function LibraryDetail() {
         </div>
       </div>
     </div>
+    </DesktopOnly>
   );
 }

--- a/src/components/PlatformLanding.jsx
+++ b/src/components/PlatformLanding.jsx
@@ -3,6 +3,7 @@ import { AlertCircle, PlayCircle, Video } from 'lucide-react';
 import themeConfig from './themeConfig';
 import PlatformNavbar from './PlatformNavbar';
 import VideoLinkInputCard from './VideoLinkInputCard';
+import DesktopOnly from './DesktopOnly';
 
 
 
@@ -56,19 +57,21 @@ function BenefitsSection({ cfg }) {
 export default function PlatformLanding() {
   const cfg = themeConfig.app;
      return (
+      <DesktopOnly>
       <div className='font-fraunces bg-white'>
       <PlatformNavbar />
       <div className="flex flex-col items-center justify-start min-h-screen pt-20">
         <VideoLinkInputCard
           cfg={cfg}
         />
-        <div id="how-to-use" className="mt-10 border-2 border-dashed border-gray-400 rounded-xl bg-white flex items-center justify-center text-gray-600 text-base sm:text-lg 
+        <div id="how-to-use" className="mt-10 border-2 border-dashed border-gray-400 rounded-xl bg-white flex items-center justify-center text-gray-600 text-base sm:text-lg
           h-[300px] sm:h-[400px] md:h-[500px] w-[1000px]">
           How to use — there will be a video here in future
         </div>
         <BenefitsSection cfg={cfg} />
       </div>
       </div>
+      </DesktopOnly>
 );
    
 }

--- a/src/components/StudyRoom.jsx
+++ b/src/components/StudyRoom.jsx
@@ -7,6 +7,7 @@ import VideoLinkInputCard from './VideoLinkInputCard.jsx';
 import themeConfig from './themeConfig';
 import SidePanel from './SidePanel.jsx';
 import { fetchUnattemptedQuestions } from '../services/questionService';
+import DesktopOnly from './DesktopOnly';
 
 
 function extractId(url) {
@@ -101,6 +102,7 @@ export default function StudyRoom() {
   }, [showIframe]);
 
   return (
+    <DesktopOnly>
     <div className="w-full h-full flex flex-col font-fraunces bg-white">
       {!showIframe ? (
         <>
@@ -143,5 +145,6 @@ export default function StudyRoom() {
         </>
       )}
     </div>
+    </DesktopOnly>
   );
 }


### PR DESCRIPTION
## Summary
- add DesktopOnly component that shows a desktop-only notice on small screens
- wrap landing, platform, library, library detail, and study room pages with the DesktopOnly gate

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: see errors)*

------
https://chatgpt.com/codex/tasks/task_e_6892d75a3728832f8a7090df30a50fb0