### PR TITLE
feat: add posthog tracking service

### DIFF
--- a/src/components/ChatView.jsx
+++ b/src/components/ChatView.jsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { ArrowRight } from 'lucide-react';
 import { useChatWebSocket } from './ChatWebSocket';
+import analytics from '../services/posthogService';
 
 
 export default function ChatView({ getCurrentTime }) {
@@ -58,9 +59,9 @@ export default function ChatView({ getCurrentTime }) {
       });
   }, []);
 
-  const handleSend = () => {
-    const trimmed = input.trim();
-    if (!trimmed) return;
+    const handleSend = () => {
+      const trimmed = input.trim();
+      if (!trimmed) return;
 
     if (!hasConnectedRef.current) {
       connect();
@@ -71,14 +72,15 @@ export default function ChatView({ getCurrentTime }) {
         setMessages((prev) => [...prev, { role: 'user', text: trimmed }]);
         sendMessage(trimmed);
       }, 3000);
-    } else {
-      // For subsequent messages, no delay needed
-      setMessages((prev) => [...prev, { role: 'user', text: trimmed }]);
-      sendMessage(trimmed);
-    }
-    
-    setInput('');
-  };
+      } else {
+        // For subsequent messages, no delay needed
+        setMessages((prev) => [...prev, { role: 'user', text: trimmed }]);
+        sendMessage(trimmed);
+      }
+      analytics.doubtAsked();
+
+      setInput('');
+    };
 
   const handleKeyDown = (e) => {
     if (e.key === 'Enter' && !e.shiftKey) {

--- a/src/components/DesktopOnly.jsx
+++ b/src/components/DesktopOnly.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import themeConfig from './themeConfig';
+import analytics from '../services/posthogService';
 
 export default function DesktopOnly({ children }) {
   const [isMobile, setIsMobile] = useState(() => window.innerWidth < 768);
@@ -11,6 +12,7 @@ export default function DesktopOnly({ children }) {
     };
 
     handleResize();
+    analytics.desktopViewLoaded();
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
   }, []);

--- a/src/components/LandingPage.jsx
+++ b/src/components/LandingPage.jsx
@@ -1,11 +1,12 @@
 // export default LandingPage;
-import React from 'react';
+import { useEffect } from 'react';
 import { Download } from 'lucide-react';
 import themeConfig from './themeConfig';
 import { landingContent  } from './landingContent';
 import { useNavigate } from 'react-router-dom';
 import Footer from './Footer';
 import Navbar from './Navbar';
+import analytics from '../services/posthogService';
 
 
 const CTAButtons = ({ center = false, showDownload = true }) => {
@@ -40,7 +41,9 @@ const CTAButtons = ({ center = false, showDownload = true }) => {
 
 const LandingPage = () => {
   const { useCases, faqs } = landingContent;
-
+  useEffect(() => {
+    analytics.websiteLoaded();
+  }, []);
 
   return (
     <div className="bg-white min-h-screen font-fraunces">

--- a/src/components/Library.jsx
+++ b/src/components/Library.jsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { fetchQuestions } from '../services/questionService';
 import { useNavigate } from 'react-router-dom';
 import DesktopOnly from './DesktopOnly';
+import analytics from '../services/posthogService';
 
 
 function CompletionCircle({ percent }) {
@@ -59,6 +60,7 @@ export default function Library() {
 
 
   useEffect(() => {
+    analytics.libraryPageLoaded();
     async function fetchTabsWithQuestions() {
       const tabData = await getTabs();
       const enrichedTabs = await Promise.all(

--- a/src/components/LibraryDetail.jsx
+++ b/src/components/LibraryDetail.jsx
@@ -4,6 +4,7 @@ import PlatformNavbar from './PlatformNavbar';
 import { fetchQuestions, submitQuestionAnswer } from '../services/questionService';
 import { SendHorizontal, CheckCircle, AlertCircle } from 'lucide-react';
 import DesktopOnly from './DesktopOnly';
+import analytics from '../services/posthogService';
 
 const getDifficultyColor = (level) => {
   if (level === 'easy') return 'bg-green-100 text-green-700';
@@ -198,6 +199,10 @@ export default function LibraryDetail() {
   const [unattempted, setUnattempted] = useState(0);
   const [questions, setQuestions] = useState([]);
   const [attemptedQuestions, setAttemptedQuestions] = useState([]);
+
+  useEffect(() => {
+    analytics.libraryDetailPageLoaded();
+  }, []);
 
   useEffect(() => {
     async function loadQuestions() {

--- a/src/components/LoginPage.jsx
+++ b/src/components/LoginPage.jsx
@@ -1,7 +1,8 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Navbar from './Navbar';
 import themeConfig from './themeConfig'; // Import themeConfig
+import analytics from '../services/posthogService';
 
 const BACKEND_URL = 'http://localhost:8000';
 
@@ -44,6 +45,10 @@ export default function GoogleLogin() {
       url.searchParams.delete('from-extension');
       window.history.replaceState({}, '', url);
     }
+  }, []);
+
+  useEffect(() => {
+    analytics.loginPageLoaded();
   }, []);
 
   async function handleCredentialResponse(response) {
@@ -95,6 +100,7 @@ export default function GoogleLogin() {
     setLoading(true);
     setError(null);
     try {
+      analytics.loginEmailSubmitted(email);
       const res = await fetch(`${BACKEND_URL}/magic-link/`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/src/components/PlatformLanding.jsx
+++ b/src/components/PlatformLanding.jsx
@@ -1,11 +1,10 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { AlertCircle, PlayCircle, Video } from 'lucide-react';
 import themeConfig from './themeConfig';
 import PlatformNavbar from './PlatformNavbar';
 import VideoLinkInputCard from './VideoLinkInputCard';
 import DesktopOnly from './DesktopOnly';
-
-
+import analytics from '../services/posthogService';
 
 function OfferingCard({ icon, iconBg, iconColor, title, description, cfg }) {
   return (
@@ -20,7 +19,6 @@ function OfferingCard({ icon, iconBg, iconColor, title, description, cfg }) {
     </div>
   );
 }
-
 
 function BenefitsSection({ cfg }) {
   return (
@@ -53,25 +51,26 @@ function BenefitsSection({ cfg }) {
   );
 }
 
-
 export default function PlatformLanding() {
   const cfg = themeConfig.app;
-     return (
-      <DesktopOnly>
-      <div className='font-fraunces bg-white'>
-      <PlatformNavbar />
-      <div className="flex flex-col items-center justify-start min-h-screen pt-20">
-        <VideoLinkInputCard
-          cfg={cfg}
-        />
-        <div id="how-to-use" className="mt-10 border-2 border-dashed border-gray-400 rounded-xl bg-white flex items-center justify-center text-gray-600 text-base sm:text-lg
-          h-[300px] sm:h-[400px] md:h-[500px] w-[1000px]">
-          How to use — there will be a video here in future
+  useEffect(() => {
+    analytics.desktopViewLoaded();
+  }, []);
+  return (
+    <DesktopOnly>
+      <div className="font-fraunces bg-white">
+        <PlatformNavbar />
+        <div className="flex flex-col items-center justify-start min-h-screen pt-20">
+          <VideoLinkInputCard cfg={cfg} />
+          <div
+            id="how-to-use"
+            className="mt-10 border-2 border-dashed border-gray-400 rounded-xl bg-white flex items-center justify-center text-gray-600 text-base sm:text-lg h-[300px] sm:h-[400px] md:h-[500px] w-[1000px]"
+          >
+            How to use — there will be a video here in future
+          </div>
+          <BenefitsSection cfg={cfg} />
         </div>
-        <BenefitsSection cfg={cfg} />
       </div>
-      </div>
-      </DesktopOnly>
-);
-   
+    </DesktopOnly>
+  );
 }

--- a/src/components/PlatformNavbar.jsx
+++ b/src/components/PlatformNavbar.jsx
@@ -2,6 +2,7 @@ import themeConfig from './themeConfig';
 import { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { ChevronDown, LogOut } from 'lucide-react';
+import analytics from '../services/posthogService';
 
 
 function UserAvatar({ profilePicture, emailPrefix }) {
@@ -61,12 +62,13 @@ export default function PlatformNavbar({ defaultTab = 'My Space' }) {
     window.location.reload(); // or redirect to login
   };
 
-  const handleTabClick = (tab) => {
-    setSelected(tab);
-    switch (tab) {
-      case 'My Space':
-        navigate('/platform');
-        break;
+    const handleTabClick = (tab) => {
+      setSelected(tab);
+      analytics.navbarOptionClicked(tab);
+      switch (tab) {
+        case 'My Space':
+          navigate('/platform');
+          break;
       case 'Study Room':
         navigate('/study-room');
         break;

--- a/src/components/StudyRoom.jsx
+++ b/src/components/StudyRoom.jsx
@@ -8,6 +8,7 @@ import themeConfig from './themeConfig';
 import SidePanel from './SidePanel.jsx';
 import { fetchUnattemptedQuestions } from '../services/questionService';
 import DesktopOnly from './DesktopOnly';
+import analytics from '../services/posthogService';
 
 
 function extractId(url) {
@@ -113,15 +114,16 @@ export default function StudyRoom() {
         </>
       ) : (
         <>
-          <StudyRoomNavbar videoUrl={videoUrl}
-            onTabSelect={(tab) => {
-            pause(); // 👈 Pause video before opening side panel
-            setSidePanelTab(tab);
-          }}
-            unattemptedQuestionCount={unattemptedQuestionCount}
-            getCurrentTime={getCurrentTime}
-            getDuration={getDuration}
-            selectedTab={sidePanelTab}/>
+            <StudyRoomNavbar videoUrl={videoUrl}
+              onTabSelect={(tab) => {
+              pause(); // 👈 Pause video before opening side panel
+              setSidePanelTab(tab);
+              analytics.sideNavbarOpened(tab);
+            }}
+              unattemptedQuestionCount={unattemptedQuestionCount}
+              getCurrentTime={getCurrentTime}
+              getDuration={getDuration}
+              selectedTab={sidePanelTab}/>
           <div className="flex flex-1 overflow-hidden"> {/* Main row: video + side panel */}
             <iframe
               ref={iframeRef}

--- a/src/components/VideoLinkInputCard.jsx
+++ b/src/components/VideoLinkInputCard.jsx
@@ -1,7 +1,8 @@
 // VideoLinkInputCard.jsx
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { PlayCircle, Loader2 } from 'lucide-react';
+import analytics from '../services/posthogService';
 
 function isValidYouTubeUrl(url) {
   try {
@@ -63,11 +64,12 @@ export default function VideoLinkInputCard({ cfg, initialUrl = '' }) {
         return;
       }
 
-      const tab = await createTab(user.id, trimmed, token);
-      localStorage.setItem('tabId', tab.id);
-      localStorage.removeItem('chatId');
-      navigate(`/study-room?video=${encodeURIComponent(trimmed)}&mode=play`);
-    } catch (err) {
+        const tab = await createTab(user.id, trimmed, token);
+        localStorage.setItem('tabId', tab.id);
+        localStorage.removeItem('chatId');
+        analytics.youtubeLearningStarted(trimmed);
+        navigate(`/study-room?video=${encodeURIComponent(trimmed)}&mode=play`);
+      } catch (err) {
       console.error(err);
       setError('Failed to initiate learning session. Please try again.');
       setLoading(false);

--- a/src/services/posthogService.js
+++ b/src/services/posthogService.js
@@ -1,0 +1,31 @@
+import posthog from 'posthog-js';
+
+function getUserId() {
+  try {
+    const stored = localStorage.getItem('user');
+    return stored ? JSON.parse(stored).id : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function capture(event, properties = {}) {
+  const user_id = getUserId();
+  posthog.capture(event, { user_id, ...properties });
+}
+
+const analytics = {
+  websiteLoaded: () => capture('website_loaded'),
+  loginPageLoaded: () => capture('login_page_loaded'),
+  loginEmailSubmitted: (email) => capture('login_email_submitted', { email }),
+  navbarOptionClicked: (option) => capture('navbar_option_clicked', { option }),
+  sideNavbarOpened: (tab) => capture('side_navbar_opened', { tab }),
+  doubtAsked: () => capture('doubt_asked'),
+  questionAttempted: (questionId) => capture('question_attempted', { question_id: questionId }),
+  libraryPageLoaded: () => capture('library_page_loaded'),
+  libraryDetailPageLoaded: () => capture('library_detail_page_loaded'),
+  youtubeLearningStarted: (url) => capture('youtube_learning_started', { url }),
+  desktopViewLoaded: () => capture('desktop_view_loaded'),
+};
+
+export default analytics;

--- a/src/services/questionService.js
+++ b/src/services/questionService.js
@@ -1,3 +1,4 @@
+import analytics from './posthogService';
 const API_BASE_URL = 'http://localhost:8000';
 
 export async function fetchUnattemptedQuestions() {
@@ -45,25 +46,27 @@ export async function fetchQuestions(tabId) {
 
 
 // In questionService.js
-export async function submitQuestionAnswer({ question_id, answer_text, answer_option }) {
-  const token = localStorage.getItem('token');
-  const response = await fetch('http://localhost:8000/question-answers', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `${token}`,
-    },
-    body: JSON.stringify({
-      question_id,
-      answer_text,
-      answer_option,
-    }),
-  });
+  export async function submitQuestionAnswer({ question_id, answer_text, answer_option }) {
+    const token = localStorage.getItem('token');
+    const response = await fetch('http://localhost:8000/question-answers', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `${token}`,
+      },
+      body: JSON.stringify({
+        question_id,
+        answer_text,
+        answer_option,
+      }),
+    });
 
-  if (!response.ok) {
-    const error = await response.json();
-    throw new Error(error.detail || 'Failed to submit answer');
+    if (!response.ok) {
+      const error = await response.json();
+      throw new Error(error.detail || 'Failed to submit answer');
+    }
+
+    const data = await response.json();
+    analytics.questionAttempted(question_id);
+    return data;
   }
-
-  return await response.json();
-}


### PR DESCRIPTION
## Summary
- add PostHog analytics service with user-aware helper
- fire events for page loads, navigation, and learning actions
- track desktop view load on PlatformLanding and DesktopOnly

## Testing
- `npm run lint` *(fails: `148 problems (145 errors, 3 warnings)`)*

------
https://chatgpt.com/codex/tasks/task_e_6892e7be6758832f976a133f040f284b