### PR TITLE
Comment out unused auth and extension buttons

### DIFF
--- a/src/components/LoginPage.jsx
+++ b/src/components/LoginPage.jsx
@@ -180,13 +180,17 @@ export default function GoogleLogin() {
           </p>
 
           <div className="login-options mt-6 space-y-6 flex flex-col items-center">
-            <div id="google-signin-button" />
+            {/* TODO: Re-enable Google Sign-In button */}
+            {/* <div id="google-signin-button" /> */}
 
+            {/* TODO: Restore separator when multiple login options are available */}
+            {/*
             <div className="w-[280px] flex items-center text-gray-400 text-sm">
               <hr className="flex-grow border-gray-300" />
               <span className="px-2">or</span>
               <hr className="flex-grow border-gray-300" />
             </div>
+            */}
 
             <input
               type="email"

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -72,12 +72,15 @@ const Navbar = ({
             <div className="flex items-center gap-4">
               {childrenButtons ?? (
                 <>
+                  {/* TODO: Re-enable Chrome Extension download button */}
+                  {/*
                   <button
                     className={`hidden md:inline-flex items-center gap-2 ${cfg.secondaryBtn} px-5 py-2 font-medium transition`}
                   >
                     <Download size={16} />
                     Chrome Extension
                   </button>
+                  */}
                   <button
                     onClick={() => navigate('/login')}
                     className={`${cfg.primaryBtn} transition font-medium px-3 md:px-5 py-1.5 md:py-2 text-sm md:text-base`}

--- a/src/components/StudyRoomNavbar.jsx
+++ b/src/components/StudyRoomNavbar.jsx
@@ -10,7 +10,8 @@ export default function StudyRoomNavbar({ videoUrl, onTabSelect, selectedTab, ge
   const tabs = [
     { label: 'Ask Doubt', emoji: '❓' },
     { label: 'Attempt Question', emoji: '📝' },
-    { label: 'Take Notes', emoji: '✍️' },
+    // TODO: Re-enable 'Take Notes' tab when notes feature is available
+    // { label: 'Take Notes', emoji: '✍️' },
   ];
   
 


### PR DESCRIPTION
## Summary
- Comment out Chrome extension download button in Navbar
- Comment out Google login and separator on Login page
- Temporarily remove 'Take Notes' tab from StudyRoomNavbar

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 149 problems)*

------
https://chatgpt.com/codex/tasks/task_e_6892f09f1508832fb8ad1f4e57cd4425