### PR TITLE
Allow unauthenticated study room with overlay

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -73,11 +73,7 @@ function AppRoutes() {
 
       <Route
         path="/study-room"
-        element={
-          <PrivateRoute>
-            <StudyRoom />
-          </PrivateRoute>
-        }
+        element={<StudyRoom />}
       />
 
       <Route

--- a/src/components/StudyRoom.jsx
+++ b/src/components/StudyRoom.jsx
@@ -52,6 +52,7 @@ export default function StudyRoom() {
   const startTime = extractStartTime(videoUrl);
   const [unattemptedQuestionCount, setUnattemptedQuestionCount] = useState(0);
   const { iframeRef, pause, getCurrentTime, isPlaying, getDuration } = useYouTubePlayer(videoId);
+  const isLoggedIn = Boolean(localStorage.getItem('token'));
 
   const showIframe = videoId && mode === 'play';
 
@@ -105,7 +106,7 @@ export default function StudyRoom() {
 
   return (
     <DesktopOnly>
-    <div className="w-full h-full flex flex-col font-fraunces bg-white">
+    <div className="relative w-full h-full flex flex-col font-fraunces bg-white">
       {!showIframe ? (
         <>
           <PlatformNavbar defaultTab="Study Room" />
@@ -146,6 +147,9 @@ export default function StudyRoom() {
             )}
           </div>
         </>
+      )}
+      {!isLoggedIn && (
+        <div className="absolute inset-0 bg-black/30 z-50 pointer-events-auto cursor-not-allowed" />
       )}
     </div>
     </DesktopOnly>


### PR DESCRIPTION
## Summary
- Make `/study-room` route public
- Overlay a transparent layer on the study room when user not logged in to block interactions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prop-types and lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6894e530fd9c832fade49a291d11c29a