### PR TITLE
feat: add library loading and zero states

### DIFF
--- a/src/components/Library.jsx
+++ b/src/components/Library.jsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import DesktopOnly from './DesktopOnly';
 import analytics from '../services/posthogService';
-import themeConfig from './themeConfig';
+import { Loader2 } from 'lucide-react';
 
 
 
@@ -57,15 +57,18 @@ function CompletionCircle({ percent }) {
 
 export default function Library() {
   const [tabs, setTabs] = useState([]);
+  const [loading, setLoading] = useState(true);
   const navigate = useNavigate();
-  const cfg = themeConfig.app;
-
 
   useEffect(() => {
     analytics.libraryPageLoaded();
     async function fetchTabsWithQuestions() {
-      const tabData = await getTabs();
-      setTabs(tabData);
+      try {
+        const tabData = await getTabs();
+        setTabs(tabData);
+      } finally {
+        setLoading(false);
+      }
     }
 
     fetchTabsWithQuestions();
@@ -91,67 +94,77 @@ export default function Library() {
       console.error("Invalid video URL:", tab.captured_from_url, error);
     }
   };
-  
 
   return (
     <DesktopOnly>
-    <div className="font-fraunces bg-white">
-      <PlatformNavbar defaultTab="Library" />
-      <div className="px-[100px] py-[60px]">
-        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-x-10 gap-y-10">
-        {tabs.map((tab, idx) => {
-          const percent = getCompletionPercent(tab);
-          const attempted = tab.attempted_questions || 0;
-          const unattempted = tab.unattempted_questions || 0;
+      <div className="font-fraunces bg-white">
+        <PlatformNavbar defaultTab="Library" />
+        {loading ? (
+          <div className="flex items-center justify-center h-[80vh]">
+            <Loader2 className="w-12 h-12 text-cyan-700 animate-spin" />
+          </div>
+        ) : tabs.length === 0 ? (
+          <div className="flex items-center justify-center h-[80vh] px-4">
+            <p className="text-center text-gray-500 text-lg">
+              You have not watched any videos yet. Watch videos and they will appear here.
+            </p>
+          </div>
+        ) : (
+          <div className="px-[100px] py-[60px]">
+            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-x-10 gap-y-10">
+              {tabs.map((tab, idx) => {
+                const percent = getCompletionPercent(tab);
+                const attempted = tab.attempted_questions || 0;
+                const unattempted = tab.unattempted_questions || 0;
 
-          return (
-            <div
-              key={idx}
-              className="flex flex-col bg-white/40 backdrop-blur-lg border border-white/30 rounded-xl shadow-lg overflow-hidden h-full w-full transition-transform hover:-translate-y-1 hover:shadow-xl group"
-            >
-              <img
-                src={tab.thumbnail}
-                alt={tab.page_title}
-                className="w-full h-56 object-cover transition-transform duration-300 ease-in-out transform group-hover:scale-105 group-hover:brightness-90 cursor-pointer"
-                onClick={() => handleThumbnailClick(tab)}
-              />
-              <div className="p-4 flex-grow flex flex-col items-start">
-              <div
-                className="text-[15px] font-medium text-black-500 leading-tight line-clamp-2 h-[3.5em] group-hover:text-cyan-700 transition-colors duration-300 cursor-pointer"
-                onClick={() => handleThumbnailClick(tab)}
-              >
-                {tab.page_title}
-              </div>
+                return (
+                  <div
+                    key={idx}
+                    className="flex flex-col bg-white/40 backdrop-blur-lg border border-white/30 rounded-xl shadow-lg overflow-hidden h-full w-full transition-transform hover:-translate-y-1 hover:shadow-xl group"
+                  >
+                    <img
+                      src={tab.thumbnail}
+                      alt={tab.page_title}
+                      className="w-full h-56 object-cover transition-transform duration-300 ease-in-out transform group-hover:scale-105 group-hover:brightness-90 cursor-pointer"
+                      onClick={() => handleThumbnailClick(tab)}
+                    />
+                    <div className="p-4 flex-grow flex flex-col items-start">
+                      <div
+                        className="text-[15px] font-medium text-black-500 leading-tight line-clamp-2 h-[3.5em] group-hover:text-cyan-700 transition-colors duration-300 cursor-pointer"
+                        onClick={() => handleThumbnailClick(tab)}
+                      >
+                        {tab.page_title}
+                      </div>
 
-                <div className="mt-4 w-full grid grid-cols-3 gap-2 items-center bg-gray-50/70 backdrop-blur-sm px-4 py-4 rounded-lg shadow-inner relative group/stats">
-                  <CompletionCircle percent={percent} />
+                      <div className="mt-4 w-full grid grid-cols-3 gap-2 items-center bg-gray-50/70 backdrop-blur-sm px-4 py-4 rounded-lg shadow-inner relative group/stats">
+                        <CompletionCircle percent={percent} />
 
-                  <div className="flex flex-col items-center justify-center text-sm text-gray-700 col-span-2">
-                    <div className="text-base font-bold">
-                      {attempted} / {attempted + unattempted}
+                        <div className="flex flex-col items-center justify-center text-sm text-gray-700 col-span-2">
+                          <div className="text-base font-bold">
+                            {attempted} / {attempted + unattempted}
+                          </div>
+                          <div className="text-xs text-center">Questions Attempted</div>
+
+                          <button
+                            className="mt-2 px-3 py-1 text-xs bg-gradient-to-r from-[#0284c7] via-[#0ea5e9] to-[#22d3ee] hover:from-[#0369a1] hover:to-[#06b6d4] text-white font-medium rounded-lg shadow transition-transform hover:-translate-y-0.5 opacity-0 group-hover/stats:opacity-100 pointer-events-auto"
+                            onClick={() => {
+                              navigate(`/library/${tab.id}`, {
+                                state: { pageTitle: tab.page_title },
+                              });
+                            }}
+                          >
+                            View Questions
+                          </button>
+                        </div>
+                      </div>
                     </div>
-                    <div className="text-xs text-center">Questions Attempted</div>
-
-                    <button
-                      className="mt-2 px-3 py-1 text-xs bg-gradient-to-r from-[#0284c7] via-[#0ea5e9] to-[#22d3ee] hover:from-[#0369a1] hover:to-[#06b6d4] text-white font-medium rounded-lg shadow transition-transform hover:-translate-y-0.5 opacity-0 group-hover/stats:opacity-100 pointer-events-auto"
-                      onClick={() => {
-                        navigate(`/library/${tab.id}`, {
-                          state: { pageTitle: tab.page_title },
-                        });
-                      }}
-                    >
-                      View Questions
-                    </button>
                   </div>
-                </div>
-              </div>
+                );
+              })}
             </div>
-          );
-        })}
-
-        </div>
+          </div>
+        )}
       </div>
-    </div>
     </DesktopOnly>
   );
 }


### PR DESCRIPTION
## Summary
- show animated spinner while library content loads
- display friendly empty state when no videos have been watched

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 162 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68990935783083208812ad85e9860220