### PR TITLE
chore: refine library messaging

### DIFF
--- a/src/components/Library.jsx
+++ b/src/components/Library.jsx
@@ -100,13 +100,14 @@ export default function Library() {
       <div className="font-fraunces bg-white">
         <PlatformNavbar defaultTab="Library" />
         {loading ? (
-          <div className="flex items-center justify-center h-[80vh]">
+          <div className="flex flex-col items-center justify-center h-[80vh] space-y-4">
             <Loader2 className="w-12 h-12 text-cyan-700 animate-spin" />
+            <p className="text-gray-600 text-lg">Synchronizing your Library records…</p>
           </div>
         ) : tabs.length === 0 ? (
           <div className="flex items-center justify-center h-[80vh] px-4">
             <p className="text-center text-gray-500 text-lg">
-              You have not watched any videos yet. Watch videos and they will appear here.
+              Your Library is empty. Watch a video in the Study Room and your viewing history will appear here for easy revisits.
             </p>
           </div>
         ) : (

--- a/src/components/QuestionView.jsx
+++ b/src/components/QuestionView.jsx
@@ -183,15 +183,24 @@ function SubjectiveQuestion({ question, updateQuestionCount, theme }) {
 export default function QuestionView({ updateQuestionCount }) {
   const cfg = themeConfig.app;
   const [questions, setQuestions] = useState([]);
+  const [loaded, setLoaded] = useState(false);
 
   useEffect(() => {
     const load = async () => {
       const data = await fetchUnattemptedQuestions();
       setQuestions(data);
+      setLoaded(true);
     };
     load();
   }, []);
 
+  if (loaded && questions.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-full p-4 text-center text-gray-500">
+        Start in the Study Room—watch the video and take the quiz; your progress and history will appear here.
+      </div>
+    );
+  }
 
   const grouped = {
     mcq: questions.filter((q) => q.type === 'mcq'),


### PR DESCRIPTION
## Summary
- show loading text while syncing library entries
- clarify empty library and attempt question states

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 160 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68990e944d9c8320a04a525dcee6e664