### PR TITLE
feat: add notes view to library cards

### DIFF
--- a/src/components/Library.jsx
+++ b/src/components/Library.jsx
@@ -5,6 +5,7 @@ import { useNavigate } from 'react-router-dom';
 import DesktopOnly from './DesktopOnly';
 import analytics from '../services/posthogService';
 import { Loader2 } from 'lucide-react';
+import notesIcon from '../assets/raw_notes.png';
 
 
 
@@ -140,7 +141,7 @@ export default function Library() {
                       <div className="mt-4 w-full grid grid-cols-3 gap-2 items-center bg-gray-50/70 backdrop-blur-sm px-4 py-4 rounded-lg shadow-inner relative group/stats">
                         <CompletionCircle percent={percent} />
 
-                        <div className="flex flex-col items-center justify-center text-sm text-gray-700 col-span-2">
+                        <div className="flex flex-col items-center justify-center text-sm text-gray-700">
                           <div className="text-base font-bold">
                             {attempted} / {attempted + unattempted}
                           </div>
@@ -149,12 +150,26 @@ export default function Library() {
                           <button
                             className="mt-2 px-3 py-1 text-xs bg-gradient-to-r from-[#0284c7] via-[#0ea5e9] to-[#22d3ee] hover:from-[#0369a1] hover:to-[#06b6d4] text-white font-medium rounded-lg shadow transition-transform hover:-translate-y-0.5 opacity-0 group-hover/stats:opacity-100 pointer-events-auto"
                             onClick={() => {
-                              navigate(`/library/${tab.id}`, {
+                              navigate(`/library/${tab.id}?view=questions`, {
                                 state: { pageTitle: tab.page_title },
                               });
                             }}
                           >
                             View Questions
+                          </button>
+                        </div>
+
+                        <div className="flex flex-col items-center justify-center">
+                          <img src={notesIcon} alt="Notes" className="w-10 h-10" />
+                          <button
+                            className="mt-2 px-3 py-1 text-xs bg-gradient-to-r from-[#0284c7] via-[#0ea5e9] to-[#22d3ee] hover:from-[#0369a1] hover:to-[#06b6d4] text-white font-medium rounded-lg shadow transition-transform hover:-translate-y-0.5 opacity-0 group-hover/stats:opacity-100 pointer-events-auto"
+                            onClick={() => {
+                              navigate(`/library/${tab.id}?view=notes`, {
+                                state: { pageTitle: tab.page_title },
+                              });
+                            }}
+                          >
+                            View Notes
                           </button>
                         </div>
                       </div>

--- a/src/components/LibraryDetail.jsx
+++ b/src/components/LibraryDetail.jsx
@@ -6,6 +6,7 @@ import { CheckCircle, AlertCircle } from 'lucide-react';
 import DesktopOnly from './DesktopOnly';
 import analytics from '../services/posthogService';
 import themeConfig from './themeConfig';
+import NoteView from './NoteView';
 
 
 const getDifficultyColor = (level) => {
@@ -205,6 +206,7 @@ export default function LibraryDetail() {
   const { tabId } = useParams();
   const location = useLocation();
   const pageTitle = location.state?.pageTitle;
+  const view = new URLSearchParams(location.search).get('view') || 'questions';
 
   const [attempted, setAttempted] = useState(0);
   const [unattempted, setUnattempted] = useState(0);
@@ -217,6 +219,7 @@ export default function LibraryDetail() {
   }, []);
 
   useEffect(() => {
+    if (view === 'notes') return;
     async function loadQuestions() {
       if (!tabId) return;
       const result = await fetchQuestions(tabId);
@@ -226,7 +229,7 @@ export default function LibraryDetail() {
       setAttemptedQuestions(result.attempted || []);
     }
     loadQuestions();
-  }, [tabId]);
+  }, [tabId, view]);
 
   const grouped = {
     mcq: questions.filter((q) => q.type === 'mcq'),
@@ -244,6 +247,31 @@ export default function LibraryDetail() {
     setAttempted((prev) => prev + 1);
     setUnattempted((prev) => Math.max(prev - 1, 0));
   };
+
+  if (view === 'notes') {
+    return (
+      <DesktopOnly>
+        <div className="min-h-screen bg-white flex flex-col font-fraunces">
+          <PlatformNavbar defaultTab="Library" />
+
+          <div className="flex justify-center mt-[60px] mb-[60px]">
+            <div className="w-full max-w-4xl px-4">
+              {pageTitle ? (
+                <>
+                  <div className="text-2xl font-medium text-black-500 mb-4 text-center">{pageTitle}</div>
+                  <NoteView tabId={tabId} />
+                </>
+              ) : (
+                <p className="text-red-500 text-center">
+                  Page title not available. Please navigate from the Library page.
+                </p>
+              )}
+            </div>
+          </div>
+        </div>
+      </DesktopOnly>
+    );
+  }
 
   return (
     <DesktopOnly>


### PR DESCRIPTION
## Summary
- show notes icon beside questions on library cards
- add `?view` query support for switching between questions and notes

## Testing
- `npm run lint` *(fails: 'tabId' is missing in props validation, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_689910aa952083209eccb2b3d1db020c