### PR TITLE
Standardize library icons and remove hover CTAs

### DIFF
--- a/src/components/Library.jsx
+++ b/src/components/Library.jsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import DesktopOnly from './DesktopOnly';
 import analytics from '../services/posthogService';
-import { Loader2, Notebook } from 'lucide-react';
+import { Loader2, Notebook, BookCheck } from 'lucide-react';
 
 
 
@@ -15,10 +15,10 @@ function CompletionCircle({ percent, onClick }) {
   const strokeColor = percent < 50 ? '#ef4444' : '#10b981'; // red / green
 
   return (
-    <div
-      className="flex flex-col items-center justify-center text-sm text-gray-600 cursor-pointer"
-      onClick={onClick}
-    >
+      <div
+        className="flex flex-col items-center justify-center text-sm text-gray-700 cursor-pointer"
+        onClick={onClick}
+      >
       <svg className="w-14 h-14" viewBox="0 0 60 60">
         <circle
           cx="30"
@@ -51,12 +51,13 @@ function CompletionCircle({ percent, onClick }) {
           {percent}%
         </text>
       </svg>
-      <div className="text-xs text-center leading-tight mt-1">
-        Tutorial<br />Completed
+        <div className="text-xs text-center leading-tight mt-1">
+          Tutorial<br />Completed
+        </div>
+        <div className="text-[10px] text-gray-400 mt-1">View</div>
       </div>
-    </div>
-  );
-}
+    );
+  }
 
 export default function Library() {
   const [tabs, setTabs] = useState([]);
@@ -140,49 +141,45 @@ export default function Library() {
                         {tab.page_title}
                       </div>
 
-                      <div className="mt-4 w-full grid grid-cols-3 gap-2 items-start bg-gray-50/70 backdrop-blur-sm px-4 py-4 rounded-lg shadow-inner relative group/stats">
-                        <CompletionCircle
-                          percent={percent}
-                          onClick={() => handleThumbnailClick(tab)}
-                        />
+              <div className="mt-4 w-full grid grid-cols-3 gap-2 items-start bg-gray-50/70 backdrop-blur-sm px-4 py-4 rounded-lg shadow-inner relative">
+                <CompletionCircle
+                  percent={percent}
+                  onClick={() => handleThumbnailClick(tab)}
+                />
 
-                        <div className="flex flex-col items-center justify-center text-sm text-gray-700">
-                          <div className="text-base font-bold">
-                            {attempted} / {attempted + unattempted}
-                          </div>
-                          <div className="text-xs text-center">Questions Attempted</div>
-
-                          <button
-                            className="mt-2 px-3 py-1 text-xs bg-gradient-to-r from-[#0284c7] via-[#0ea5e9] to-[#22d3ee] hover:from-[#0369a1] hover:to-[#06b6d4] text-white font-medium rounded-lg shadow transition-transform hover:-translate-y-0.5 opacity-0 group-hover/stats:opacity-100 pointer-events-auto"
-                            onClick={() => {
-                              navigate(`/library/${tab.id}?view=questions`, {
-                                state: { pageTitle: tab.page_title },
-                              });
-                            }}
-                          >
-                            View Questions
-                          </button>
-                        </div>
-
-                        <div className="flex flex-col items-center justify-center text-sm text-gray-700">
-                          <Notebook className="w-10 h-10 text-gray-700" />
-                          <div className="text-xs text-center mt-1">Saved Notes</div>
-                          <button
-                            className="mt-2 px-3 py-1 text-xs bg-gradient-to-r from-[#0284c7] via-[#0ea5e9] to-[#22d3ee] hover:from-[#0369a1] hover:to-[#06b6d4] text-white font-medium rounded-lg shadow transition-transform hover:-translate-y-0.5 opacity-0 group-hover/stats:opacity-100 pointer-events-auto"
-                            onClick={() => {
-                              navigate(`/library/${tab.id}?view=notes`, {
-                                state: { pageTitle: tab.page_title },
-                              });
-                            }}
-                          >
-                            View Notes
-                          </button>
-                        </div>
-                      </div>
-                    </div>
+                <div
+                  className="flex flex-col items-center justify-center text-sm text-gray-700 cursor-pointer"
+                  onClick={() => {
+                    navigate(`/library/${tab.id}?view=questions`, {
+                      state: { pageTitle: tab.page_title },
+                    });
+                  }}
+                >
+                  <BookCheck className="w-14 h-14 text-gray-700" strokeWidth={1.5} />
+                  <div className="text-base font-medium mt-1">
+                    {attempted} / {attempted + unattempted}
                   </div>
-                );
-              })}
+                  <div className="text-xs text-center">Questions Attempted</div>
+                  <div className="text-[10px] text-gray-400 mt-1">View</div>
+                </div>
+
+                <div
+                  className="flex flex-col items-center justify-center text-sm text-gray-700 cursor-pointer"
+                  onClick={() => {
+                    navigate(`/library/${tab.id}?view=notes`, {
+                      state: { pageTitle: tab.page_title },
+                    });
+                  }}
+                >
+                  <Notebook className="w-14 h-14 text-gray-700" strokeWidth={1.5} />
+                  <div className="text-xs text-center mt-1">Saved Notes</div>
+                  <div className="text-[10px] text-gray-400 mt-1">View</div>
+                </div>
+              </div>
+            </div>
+          </div>
+        );
+      })}
             </div>
           </div>
         )}


### PR DESCRIPTION
## Summary
- Add BookCheck icon for attempted questions and standardize sizes for progress icons
- Remove hover-only CTAs and make question/notes stats clickable
- Add subtle 'View' text under each icon to hint interactivity

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 163 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68991621d9708320b445a30dcc46095d