### PR TITLE
Center Start Learning button and add YouTube icon

### DIFF
--- a/src/components/VideoLinkInputCard.jsx
+++ b/src/components/VideoLinkInputCard.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/prop-types */
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { PlayCircle, Loader2 } from 'lucide-react';
+import { PlayCircle, Loader2, Youtube } from 'lucide-react';
 import analytics from '../services/posthogService';
 import { API_BASE_URL } from '../config.js';
 
@@ -74,7 +74,10 @@ export default function VideoLinkInputCard({ cfg, initialUrl = '' }) {
 
   return (
     <div id="videolink-input-card" className={`w-full max-w-[600px] ${cfg.card} min-h-[250px]`}>
-      <div className={cfg.cardHeadinglarge}>Enter YouTube Video URL</div>
+      <div className={`${cfg.cardHeadinglarge} flex items-center gap-2`}>
+        <Youtube size={32} />
+        Enter YouTube Video URL
+      </div>
       <div className={cfg.cardSubheading}>
         ilon AI helps you resolve doubts, test your knowledge, and generate structured notes from raw input.
       </div>
@@ -88,7 +91,11 @@ export default function VideoLinkInputCard({ cfg, initialUrl = '' }) {
         }}
         className={cfg.inputfield}
       />
-      <button onClick={handleClick} disabled={!url.trim() || loading} className={cfg.primaryButton}>
+      <button
+        onClick={handleClick}
+        disabled={!url.trim() || loading}
+        className={`${cfg.primaryButton} mx-auto`}
+      >
         {loading ? (
           <div className="flex items-center justify-center gap-2">
             <Loader2 size={20} className="animate-spin" /> Preparing Study Room...


### PR DESCRIPTION
## Summary
- Add YouTube icon before "Enter YouTube Video URL" heading
- Center Start Learning button within the video link input card

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 163 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68991d6b25f4832087091b6aad3c28d0