### PR TITLE
Centralize tab creation in StudyRoom

### DIFF
--- a/src/components/Library.jsx
+++ b/src/components/Library.jsx
@@ -93,7 +93,6 @@
 //       const encodedUrl = encodeURIComponent(url.toString());
   
 //       navigate(`/study-room?video=${encodedUrl}&mode=play`);
-//       localStorage.setItem('tabId', tab.id);
 //     } catch (error) {
 //       console.error("Invalid video URL:", tab.captured_from_url, error);
 //     }
@@ -291,8 +290,6 @@ export default function Library() {
       const encodedUrl = encodeURIComponent(url.toString());
   
       navigate(`/study-room?video=${encodedUrl}&mode=play`);
-      localStorage.setItem('tabId', tab.id);
-      localStorage.removeItem('chatId');
     } catch (error) {
       console.error("Invalid video URL:", tab.captured_from_url, error);
     }

--- a/src/components/VideoLinkInputCard.jsx
+++ b/src/components/VideoLinkInputCard.jsx
@@ -3,7 +3,6 @@ import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { PlayCircle, Loader2, Youtube } from 'lucide-react';
 import analytics from '../services/posthogService';
-import { createTab } from '../services/tabService';
 
 
 function isValidYouTubeUrl(url) {
@@ -29,33 +28,16 @@ export default function VideoLinkInputCard({ cfg, initialUrl = '' }) {
     setUrl(initialUrl);
   }, [initialUrl]);
 
-  const handleClick = async () => {
+  const handleClick = () => {
     setError('');
-    setLoading(true);
     const trimmed = url.trim();
     if (!isValidYouTubeUrl(trimmed)) {
       setError('Please enter a valid YouTube URL');
-      setLoading(false);
       return;
     }
-    try {
-      const user = JSON.parse(localStorage.getItem('user'));
-      const token = localStorage.getItem('token');
-      if (!user || !token) {
-        setError('User not authenticated');
-        setLoading(false);
-        return;
-      }
-      const tab = await createTab(user.id, trimmed, token);
-      localStorage.setItem('tabId', tab.id);
-      localStorage.removeItem('chatId');
-      analytics.youtubeLearningStarted(trimmed);
-      navigate(`/study-room?video=${encodeURIComponent(trimmed)}&mode=play`);
-    } catch (err) {
-      console.error(err);
-      setError('Failed to initiate learning session. Please try again.');
-      setLoading(false);
-    }
+    setLoading(true);
+    analytics.youtubeLearningStarted(trimmed);
+    navigate(`/study-room?video=${encodeURIComponent(trimmed)}&mode=play`);
   };
 
   return (


### PR DESCRIPTION
## Summary
- Remove tab creation from video URL input and library thumbnail views
- Always create tab on StudyRoom load and gate other actions until complete
- Show preparing overlay while StudyRoom initializes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: numerous lint errors, see tail)*

------
https://chatgpt.com/codex/tasks/task_e_689e2ff2a8b0832f991916c5c8c51994