### PR TITLE
Open study room side panel by default and track close event

### DIFF
--- a/src/components/StudyRoom.jsx
+++ b/src/components/StudyRoom.jsx
@@ -62,6 +62,12 @@ export default function StudyRoom() {
   const showIframe = videoId && mode === 'play';
   const [isPreparingRoom, setIsPreparingRoom] = useState(showIframe && isLoggedIn);
 
+  useEffect(() => {
+    if (showIframe) {
+      setSidePanelTab('Ask Doubt');
+    }
+  }, [showIframe]);
+
   const handleUpdateTabDetails = useCallback(async (getCurrentTime, getDuration) => {
     if (!getCurrentTime || !getDuration) return;
     
@@ -236,7 +242,10 @@ export default function StudyRoom() {
             {isSidePanelOpen && (
               <SidePanel
                 tab={sidePanelTab}
-                onClose={() => setSidePanelTab(null)}
+                onClose={() => {
+                  analytics.sideNavbarClosed(sidePanelTab);
+                  setSidePanelTab(null);
+                }}
                 getCurrentTime={getCurrentTime}
                 updateQuestionCount={(delta) => {
                   setUnattemptedQuestionCount((prev) => Math.max(0, prev + delta));

--- a/src/services/posthogService.js
+++ b/src/services/posthogService.js
@@ -20,6 +20,7 @@ const analytics = {
   loginEmailSubmitted: (email) => capture('login_email_submitted', { email }),
   navbarOptionClicked: (option) => capture('navbar_option_clicked', { option }),
   sideNavbarOpened: (tab) => capture('side_navbar_opened', { tab }),
+  sideNavbarClosed: (tab) => capture('side_navbar_closed', { tab }),
   doubtAsked: () => capture('doubt_asked'),
   questionAttempted: (questionId) => capture('question_attempted', { question_id: questionId }),
   libraryPageLoaded: () => capture('library_page_loaded'),


### PR DESCRIPTION
## Summary
- Show the study room side panel with the "Ask Doubt" tab by default.
- Record a PostHog `side_navbar_closed` event when users close the side panel.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: existing repository lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a44c82cfcc832f939c2abaec1d02a1