### PR TITLE
Add 'Code from Video' option to Study Room

### DIFF
--- a/src/components/SidePanel.jsx
+++ b/src/components/SidePanel.jsx
@@ -11,6 +11,7 @@ export default function SidePanel({ tab, onClose, getCurrentTime, updateQuestion
   const getTitle = () => {
     if (tab === 'Ask Doubt') return 'Ask your doubt';
     if (tab === 'Attempt Question') return 'Practice Questions';
+    if (tab === 'Code from Video') return 'Extracted Code from Video';
     // if (tab === 'Take Notes') return 'Take Notes';
     return '';
   };
@@ -18,6 +19,13 @@ export default function SidePanel({ tab, onClose, getCurrentTime, updateQuestion
   const renderUI = () => {
     if (tab === 'Ask Doubt') return <ChatView getCurrentTime={getCurrentTime} />;
     if (tab === 'Attempt Question') return <QuestionView updateQuestionCount={updateQuestionCount} />;
+    if (tab === 'Code from Video') {
+      return (
+        <div className="p-4 text-sm text-gray-700 overflow-auto">
+          Extracted code will appear here.
+        </div>
+      );
+    }
     // if (tab === 'Take Notes') {
     //   const tabId = localStorage.getItem('tabId');
     //   return <NoteView tabId={tabId} />;

--- a/src/components/StudyRoomNavbar.jsx
+++ b/src/components/StudyRoomNavbar.jsx
@@ -1,7 +1,7 @@
 import themeConfig from './themeConfig';
 import { useEffect, useRef, useState } from 'react';
 import { updateTab } from '../services/tabService';
-import { ArrowLeft, MessageSquare, Notebook, PencilLine } from 'lucide-react';
+import { ArrowLeft, MessageSquare, PencilLine, Code } from 'lucide-react';
 
 export default function StudyRoomNavbar({
   videoUrl,
@@ -32,6 +32,10 @@ export default function StudyRoomNavbar({
     {
       label: 'Attempt Question',
       icon: <PencilLine className="w-7 h-5 text-cyan-600 group-hover:text-cyan-800" />,
+    },
+    {
+      label: 'Code from Video',
+      icon: <Code className="w-7 h-5 text-emerald-600 group-hover:text-emerald-800" />,
     },
     // {
     //   label: 'Take Notes',


### PR DESCRIPTION
## Summary
- add Code from Video tab in Study Room navbar
- show Extracted Code from Video side panel

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 193 errors, 8 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a85eb54410832fa1898898deb3e474