### PR TITLE
feat: show extracted code tasks in side panel

### DIFF
--- a/src/components/SidePanel.jsx
+++ b/src/components/SidePanel.jsx
@@ -4,6 +4,7 @@ import ChatView from './ChatView';
 import PropTypes from 'prop-types';
 import QuestionView from './QuestionView';
 import NoteView from './NoteView';
+import TasksView from './TasksView';
 
 export default function SidePanel({ tab, onClose, getCurrentTime, updateQuestionCount }) {
   const cfg = themeConfig.app;
@@ -20,11 +21,7 @@ export default function SidePanel({ tab, onClose, getCurrentTime, updateQuestion
     if (tab === 'Ask Doubt') return <ChatView getCurrentTime={getCurrentTime} />;
     if (tab === 'Attempt Question') return <QuestionView updateQuestionCount={updateQuestionCount} />;
     if (tab === 'Code from Video') {
-      return (
-        <div className="p-4 text-sm text-gray-700 overflow-auto">
-          Extracted code will appear here.
-        </div>
-      );
+      return <TasksView />;
     }
     // if (tab === 'Take Notes') {
     //   const tabId = localStorage.getItem('tabId');

--- a/src/components/TasksView.jsx
+++ b/src/components/TasksView.jsx
@@ -1,0 +1,55 @@
+import React, { useEffect, useState } from 'react';
+import MarkdownRenderer from './MarkdownRenderer';
+import { fetchTasks } from '../services/taskService';
+
+export default function TasksView() {
+  const tabId = localStorage.getItem('tabId');
+  const [tasks, setTasks] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function load() {
+      if (!tabId) {
+        setTasks([]);
+        setLoading(false);
+        return;
+      }
+      try {
+        const data = await fetchTasks(tabId);
+        const list = Array.isArray(data) ? data : data?.tasks || [];
+        setTasks(list);
+      } catch (e) {
+        console.error('Failed to fetch tasks:', e);
+        setTasks([]);
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, [tabId]);
+
+  if (loading) {
+    return <div className="p-4 text-sm text-gray-700">Loading...</div>;
+  }
+
+  if (!tasks.length) {
+    return (
+      <div className="p-4 text-sm text-gray-700">
+        There is no extracted code from the video
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-4 text-sm text-gray-700 overflow-auto space-y-4">
+      {tasks.map((task, idx) => (
+        <div key={idx} className="space-y-2">
+          {task.description && <p className="text-gray-800">{task.description}</p>}
+          {task.code && (
+            <MarkdownRenderer text={`\n\u0060\u0060\u0060\n${task.code}\n\u0060\u0060\u0060\n`} />
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/services/taskService.js
+++ b/src/services/taskService.js
@@ -1,0 +1,23 @@
+import { API_BASE_URL } from '../config.js';
+
+function authHeaders() {
+  const token = localStorage.getItem('token');
+  const h = { 'Content-Type': 'application/json' };
+  if (token) h.Authorization = token;
+  return h;
+}
+
+export async function fetchTasks(tabId) {
+  const res = await fetch(`${API_BASE_URL}/tasks/list/${tabId}`, {
+    method: 'GET',
+    headers: authHeaders(),
+  });
+  const text = await res.text();
+  if (!res.ok) {
+    const err = new Error(`fetchTasks failed (${res.status}): ${text}`);
+    err.status = res.status;
+    err.body = text;
+    throw err;
+  }
+  return JSON.parse(text);
+}


### PR DESCRIPTION
## Summary
- fetch code tasks from `/tasks/list/{tabId}` via new task service
- display tasks with descriptions and markdown code blocks in new `TasksView`
- hook tasks view into SidePanel "Code from Video" tab

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 194 errors, 8 warnings)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a863d09554832fb7195b2eecbf96e9