### PR TITLE
feat: add code extraction button

### DIFF
--- a/src/components/TasksView.jsx
+++ b/src/components/TasksView.jsx
@@ -1,11 +1,15 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import MarkdownRenderer from './MarkdownRenderer';
-import { fetchTasks } from '../services/taskService';
+import { fetchTasks, createTasks } from '../services/taskService';
+import themeConfig from './themeConfig';
+import { Loader2 } from 'lucide-react';
 
 export default function TasksView() {
+  const cfg = themeConfig.app;
   const tabId = localStorage.getItem('tabId');
   const [tasks, setTasks] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [extracting, setExtracting] = useState(false);
 
   useEffect(() => {
     async function load() {
@@ -28,28 +32,54 @@ export default function TasksView() {
     load();
   }, [tabId]);
 
+  const handleExtract = async () => {
+    if (!tabId) return;
+    setExtracting(true);
+    try {
+      const data = await createTasks(tabId);
+      const list = Array.isArray(data) ? data : data?.tasks || [];
+      if (list.length) {
+        setTasks((prev) => [...prev, ...list]);
+      }
+    } catch (e) {
+      console.error('Failed to extract code:', e);
+    } finally {
+      setExtracting(false);
+    }
+  };
+
   if (loading) {
     return <div className="p-4 text-sm text-gray-700">Loading...</div>;
   }
 
-  if (!tasks.length) {
-    return (
-      <div className="p-4 text-sm text-gray-700">
-        There is no extracted code from the video
-      </div>
-    );
-  }
-
   return (
     <div className="p-4 text-sm text-gray-700 overflow-auto space-y-4">
-      {tasks.map((task, idx) => (
-        <div key={idx} className="space-y-2">
-          {task.description && <p className="text-gray-800">{task.description}</p>}
-          {task.code && (
-            <MarkdownRenderer text={`\n\u0060\u0060\u0060\n${task.code}\n\u0060\u0060\u0060\n`} />
-          )}
-        </div>
-      ))}
+      <button
+        onClick={handleExtract}
+        disabled={extracting}
+        className={cfg.primaryButton}
+      >
+        {extracting ? (
+          <div className="flex items-center justify-center gap-2">
+            <Loader2 size={20} className="animate-spin" /> Extracting...
+          </div>
+        ) : (
+          'Extract Code'
+        )}
+      </button>
+
+      {!tasks.length ? (
+        <div>There is no extracted code from the video</div>
+      ) : (
+        tasks.map((task, idx) => (
+          <div key={idx} className="space-y-2">
+            {task.description && <p className="text-gray-800">{task.description}</p>}
+            {task.code && (
+              <MarkdownRenderer text={`\n\u0060\u0060\u0060${task.language ? task.language : ''}\n${task.code}\n\u0060\u0060\u0060\n`} />
+            )}
+          </div>
+        ))
+      )}
     </div>
   );
 }

--- a/src/services/taskService.js
+++ b/src/services/taskService.js
@@ -21,3 +21,19 @@ export async function fetchTasks(tabId) {
   }
   return JSON.parse(text);
 }
+
+export async function createTasks(tabId) {
+  const res = await fetch(`${API_BASE_URL}/tasks/create`, {
+    method: 'POST',
+    headers: authHeaders(),
+    body: JSON.stringify({ tab_id: Number(tabId) }),
+  });
+  const text = await res.text();
+  if (!res.ok) {
+    const err = new Error(`createTasks failed (${res.status}): ${text}`);
+    err.status = res.status;
+    err.body = text;
+    throw err;
+  }
+  return JSON.parse(text);
+}


### PR DESCRIPTION
## Summary
- add `createTasks` service to call /tasks/create with tab id
- add "Extract Code" button that disables and shows spinner while appending new tasks

## Testing
- `npm test` *(fails: Missing script "test"?)*
- `npm run lint` *(fails: react/prop-types, no-unused-vars, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a8682f3de4832fa79f5afc389f90d0