### PR TITLE
Add public roadmap route with placeholder components

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,6 +14,8 @@ import VerifyLearner from './components/VerifyLearner';
 import Library from './components/Library';
 import StudyRoom from './components/StudyRoom'; // ✅ correct
 import LibraryDetail from './components/LibraryDetail'; // new file
+import ChatRoadmap from './components/ChatRoadmap';
+import RoadMapUI from './components/RoadMapUI';
 
 
 
@@ -98,6 +100,15 @@ function AppRoutes() {
       <Route path="/verify-learner" element={<VerifyLearner />} />
       <Route path="/privacy-policy" element={<PrivacyPolicy />} />
       <Route path="/error" element={<ErrorPage />} />
+      <Route
+        path="/roadmap"
+        element={(
+          <>
+            <ChatRoadmap />
+            <RoadMapUI />
+          </>
+        )}
+      />
 
       {/* Fallback */}
       <Route

--- a/src/components/ChatRoadmap.jsx
+++ b/src/components/ChatRoadmap.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function ChatRoadmap() {
+  return (
+    <div className="h-screen flex items-center justify-center">
+      <h1>Hello world ChatRoadmap</h1>
+    </div>
+  );
+}

--- a/src/components/RoadMapUI.jsx
+++ b/src/components/RoadMapUI.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function RoadMapUI() {
+  return (
+    <div className="h-screen flex items-center justify-center">
+      <h1>Hello world RoadMapUI</h1>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add ChatRoadmap and RoadMapUI placeholder components
- Expose new /roadmap route rendering the new components for all users

## Testing
- `npm run lint` *(fails: 'tabId' is missing in props validation et al.)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a96dbcf9dc832f8bfb6dffa17da1b5