### PR TITLE
Add roadmap websocket chat support

### DIFF
--- a/src/components/ChatWebSocket.js
+++ b/src/components/ChatWebSocket.js
@@ -20,7 +20,7 @@ export function useChatWebSocket({ onMessage, onToken, getPlaybackTime } = {}) {
       params.append('chatId', storedChatId);
     }
 
-      const ws = new WebSocket(`${WS_BASE_URL}/ws/chat?${params.toString()}`);
+    const ws = new WebSocket(`${WS_BASE_URL}/ws/chat?${params.toString()}`);
     wsRef.current = ws;
 
     ws.onmessage = (event) => {
@@ -52,7 +52,7 @@ export function useChatWebSocket({ onMessage, onToken, getPlaybackTime } = {}) {
     try {
       if (wsRef.current?.readyState === WebSocket.OPEN) {
         const playbackTime = getPlaybackTime ? Math.floor(getPlaybackTime()) : 0;
-        
+
         // Merge playback time with the data object and send
         wsRef.current.send(JSON.stringify({
           ...data,

--- a/src/components/RoadmapWebSocket.js
+++ b/src/components/RoadmapWebSocket.js
@@ -1,0 +1,49 @@
+import { useRef } from 'react';
+import { WS_BASE_URL } from '../config.js';
+
+export function useRoadmapWebSocket({ onMessage } = {}) {
+  const wsRef = useRef(null);
+
+  const connect = () => {
+    if (wsRef.current) return; // avoid reconnecting if already connected
+
+    const ws = new WebSocket(`${WS_BASE_URL}/ws/roadmap`);
+    wsRef.current = ws;
+
+    ws.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        if (data.message !== undefined) {
+          onMessage?.(data.message);
+        } else {
+          onMessage?.(data);
+        }
+      } catch {
+        onMessage?.(event.data);
+      }
+    };
+
+    ws.onclose = () => {
+      console.log('[Roadmap WebSocket Closed]');
+      wsRef.current = null;
+    };
+  };
+
+  const close = () => {
+    wsRef.current?.close();
+  };
+
+  const sendMessage = (data) => {
+    try {
+      if (wsRef.current?.readyState === WebSocket.OPEN) {
+        wsRef.current.send(JSON.stringify(data));
+      } else {
+        console.warn('WebSocket is not open.');
+      }
+    } catch (error) {
+      console.error('Error sending WebSocket message:', error);
+    }
+  };
+
+  return { connect, sendMessage, close };
+}


### PR DESCRIPTION
## Summary
- create dedicated websocket hook for roadmap chats without tab or token params
- switch ChatRoadmap to the new hook and delay first message by three seconds
- restore the original ChatWebSocket implementation for regular chats

## Testing
- `npm run lint` *(fails: 'tabId' is missing in props validation, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a9b845f99c832f85d47d720062654a