### PR TITLE
feat: load roadmap messages from API

### DIFF
--- a/src/components/ChatRoadmap.jsx
+++ b/src/components/ChatRoadmap.jsx
@@ -20,6 +20,7 @@ import {
 } from "react-icons/si";
 import MarkdownRenderer from "./MarkdownRenderer";
 import { useRoadmapWebSocket } from "../services/RoadmapWebSocket";
+import { fetchRoadmapMessages } from "../services/roadmapMessageService";
 
 /* =========================
    Config / Constants
@@ -321,6 +322,16 @@ export default function ChatRoadmap() {
   // typewriter (pauses while typing/focused)
   const typed = useTypewriter(ROTATING_PROMPTS, isFocused || input.length > 0);
 
+  useEffect(() => {
+    const roadmapId = localStorage.getItem('roadmapId');
+    if (!roadmapId) return;
+    fetchRoadmapMessages(roadmapId)
+      .then((loaded) => setMessages(loaded))
+      .catch((err) => {
+        console.error('Failed to load messages', err);
+      });
+  }, []);
+
   const hasMessages = messages.length > 0;
 
   // handlers
@@ -351,7 +362,7 @@ export default function ChatRoadmap() {
     setInput('');
     setIsLoading(false);
     hasConnectedRef.current = false;
-    localStorage.removeItem("oadmapId");
+    localStorage.removeItem("roadmapId");
     close();
   }, [close]);
 

--- a/src/services/roadmapMessageService.js
+++ b/src/services/roadmapMessageService.js
@@ -1,0 +1,21 @@
+import { API_BASE_URL } from '../config.js';
+
+export async function fetchRoadmapMessages(roadmapId) {
+  const token = localStorage.getItem('token');
+  if (!roadmapId) return [];
+
+  const headers = token ? { Authorization: token } : {};
+
+  try {
+    const res = await fetch(`${API_BASE_URL}/messages/${roadmapId}`, { headers });
+    if (!res.ok) throw new Error('Failed to fetch messages');
+    const data = await res.json();
+    return (data.messages || []).map((m) => ({
+      role: m.message_from === 'assistant' ? 'agent' : 'user',
+      text: m.text,
+    }));
+  } catch (err) {
+    console.error('Error fetching roadmap messages:', err);
+    return [];
+  }
+}


### PR DESCRIPTION
## Summary
- add roadmapMessageService to fetch messages by roadmapId
- load existing roadmap chat messages on /roadmap when roadmapId exists in localStorage
- ensure reset removes roadmapId from localStorage

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 225 errors)


------
https://chatgpt.com/codex/tasks/task_e_68aa030b1930832fbfce50d60efeb45d