### PR TITLE
Add roadmap chat websocket hook and chat page

### DIFF
--- a/src/hooks/ChatRoadMap.jsx
+++ b/src/hooks/ChatRoadMap.jsx
@@ -1,0 +1,27 @@
+import { useState, useCallback } from 'react';
+import { useRoadmapWebSocket } from '../services/RoadmapWebSocket.js';
+
+export function useChatRoadmap() {
+  const [messages, setMessages] = useState([]);
+
+  const { connect, sendMessage } = useRoadmapWebSocket({
+    onMessage: (msg) => {
+      const text = typeof msg === 'string'
+        ? msg
+        : msg.message || JSON.stringify(msg);
+      setMessages((prev) => [...prev, { role: 'agent', text }]);
+    },
+  });
+
+  const sendUserMessage = useCallback(
+    (text) => {
+      if (!text) return;
+      setMessages((prev) => [...prev, { role: 'user', text }]);
+      connect();
+      sendMessage({ text, message_type: 'text' });
+    },
+    [connect, sendMessage]
+  );
+
+  return { messages, sendUserMessage };
+}

--- a/src/pages/ChatRoadmap.jsx
+++ b/src/pages/ChatRoadmap.jsx
@@ -1,95 +1,50 @@
-// import React, { useMemo, useCallback } from "react";
-// import {
-//   ROTATING_PROMPTS,
-//   BG_ICONS,
-//   useTypewriter
-// } from "./chatroadmapcomponents"
-// import { useRoadmapManager } from "./chatroadmapcomponents";
-// import { BackgroundIconCloud } from "./chatroadmapcomponents";
-// import { RoadmapDisplayView } from "./chatroadmapcomponents";
-// import { RoadmapChatView } from "./chatroadmapcomponents";
-// import { useWebSocketChat } from "./chatroadmapcomponents";
-// import { MessageList } from "./chatroadmapcomponents";
+import { useState, useRef } from 'react';
+import { BackgroundIconCloud, MessageList } from '../components/chatroadmapcomponents';
+import { useChatRoadmap } from '../hooks/ChatRoadMap';
 
-// export default function ChatRoadmap() {
-
-//   const {
-//     existingRoadmap,
-//     roadmapLoading,
-//     chatDisabled,
-//     updateTopicInRoadmap,
-//     setRoadmapData,
-//     resetRoadmapData,
-//   } = useRoadmapManager();
-
-//   const {
-//     messages,
-//     input,
-//     setInput,
-//     isLoading,
-//     isFocused,
-//     setIsFocused,
-//     messageContainerRef,
-//     handleSend,
-//     resetChatState,
-//     hasMessages,
-//   } = useWebSocketChat({
-//     onTopicUpdate: updateTopicInRoadmap,
-//     onRoadmapCreate: setRoadmapData,
-//   });
-
-//   const typed = useTypewriter(ROTATING_PROMPTS, isFocused || input.length > 0);
-
-//   const resetChat = useCallback(async () => {
-//     await resetRoadmapData();
-//     resetChatState();
-//   }, [resetRoadmapData, resetChatState]);
-
-//   const icons = useMemo(() => BG_ICONS, []);
-
-//   return (
-//     <>
-//       <div className="relative w-full overflow-hidden min-h-screen text-slate-900 selection:bg-emerald-300/30 font-fraunces bg-white">
-
-//         <BackgroundIconCloud icons={icons} />
-
-//         {!roadmapLoading && existingRoadmap && (
-//           <RoadmapDisplayView
-//             existingRoadmap={existingRoadmap}
-//             onReset={resetChat}
-//           />
-//         )}
-
-//         {!roadmapLoading && !existingRoadmap && (
-//           <RoadmapChatView
-//             hasMessages={hasMessages}
-//             chatDisabled={chatDisabled}
-//             input={input}
-//             setInput={setInput}
-//             typed={typed}
-//             handleSend={handleSend}
-//             onReset={resetChat}
-//             isLoading={isLoading}
-//             setIsFocused={setIsFocused}
-//             messages={messages}
-//             messageContainerRef={messageContainerRef}
-//             MessageList={MessageList}
-//           />
-//         )}
-
-//       </div>
-//     </>
-//   );
-// }
-
-
-import { BackgroundIconCloud } from "../components/chatroadmapcomponents";
+const RoadmapHeading = () => (
+  <h1 className="text-2xl font-bold mb-4">Roadmap Chat</h1>
+);
 
 export default function ChatRoadmap() {
+  const [input, setInput] = useState('');
+  const { messages, sendUserMessage } = useChatRoadmap();
+  const containerRef = useRef(null);
+
+  const handleSend = () => {
+    const trimmed = input.trim();
+    if (!trimmed) return;
+    sendUserMessage(trimmed);
+    setInput('');
+  };
 
   return (
-    <div>
+    <div className="p-4">
       <BackgroundIconCloud />
+      {messages.length === 0 ? (
+        <RoadmapHeading />
+      ) : (
+        <MessageList
+          messages={messages}
+          isLoading={false}
+          containerRef={containerRef}
+        />
+      )}
+      <div className="mt-4 flex gap-2">
+        <input
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          className="border p-2 flex-1"
+          placeholder="Type a message"
+        />
+        <button
+          onClick={handleSend}
+          className="px-4 py-2 bg-blue-500 text-white rounded"
+        >
+          Send
+        </button>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add `useChatRoadmap` hook to wrap roadmap websocket
- update ChatRoadmap page to use hook and MessageList UI
- hide roadmap heading after user sends first message

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 277 problems, 266 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b09ad8e404832fa4c519da38312404