### PR TITLE
Add chat roadmap hook and websocket chat integration

### DIFF
--- a/src/components/chatroadmap/TextareaInput.jsx
+++ b/src/components/chatroadmap/TextareaInput.jsx
@@ -1,11 +1,17 @@
 // TextAreaInput.jsx
-import React, { useState } from 'react';
 import { ArrowRight } from 'lucide-react';
+import PropTypes from 'prop-types';
 import { useTypewriter } from '../../hooks/useTypewriter';
 
-export default function TextAreaInput({ prompts = [] }) {
-  const [value, setValue] = useState('');
+export default function TextAreaInput({ prompts = [], value = '', onChange, onSend }) {
   const hint = useTypewriter({ prompts });
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      onSend?.();
+    }
+  };
 
   return (
     <div className="border rounded-xl flex items-start px-2 py-1 shadow-sm bg-white/70 backdrop-blur-md">
@@ -21,7 +27,8 @@ export default function TextAreaInput({ prompts = [] }) {
         <textarea
           rows={3}
           value={value}
-          onChange={(e) => setValue(e.target.value)}
+          onChange={(e) => onChange?.(e.target.value)}
+          onKeyDown={handleKeyDown}
           className="w-full resize-none px-3 py-2 text-sm focus:outline-none focus:ring-0 border-none scrollbar-hide bg-transparent"
           style={{ maxHeight: '120px', minHeight: '40px', overflowY: 'auto' }}
         />
@@ -30,22 +37,19 @@ export default function TextAreaInput({ prompts = [] }) {
       <div className="flex-col space-y-2">
         {/* Send button - now square */}
         <div className="flex justify-end">
-        <button
-          className="mt-2 h-[30px] w-[30px] sm:h-[40px] sm:w-[40px] flex items-center justify-center 
-                     bg-gradient-to-r from-[#0284c7] via-[#0ea5e9] to-[#22d3ee] 
-                     hover:from-[#0369a1] hover:to-[#06b6d4] text-white 
-                     rounded-lg transition-all"
-          title="Send"
-        >
-          <ArrowRight size={20} />
-        </button>
+          <button
+            onClick={onSend}
+            className="mt-2 h-[30px] w-[30px] sm:h-[40px] sm:w-[40px] flex items-center justify-center bg-gradient-to-r from-[#0284c7] via-[#0ea5e9] to-[#22d3ee] hover:from-[#0369a1] hover:to-[#06b6d4] text-white rounded-lg transition-all"
+            title="Send"
+          >
+            <ArrowRight size={20} />
+          </button>
         </div>
 
         {/* Restart button */}
         <button
           type="button"
-          className="text-xs font-medium bg-gradient-to-r from-[#0284c7] via-[#0ea5e9] to-[#22d3ee] 
-                     bg-clip-text text-transparent hover:underline cursor-pointer"
+          className="text-xs font-medium bg-gradient-to-r from-[#0284c7] via-[#0ea5e9] to-[#22d3ee] bg-clip-text text-transparent hover:underline cursor-pointer"
         >
           + Start Again
         </button>
@@ -53,3 +57,10 @@ export default function TextAreaInput({ prompts = [] }) {
     </div>
   );
 }
+
+TextAreaInput.propTypes = {
+  prompts: PropTypes.arrayOf(PropTypes.string),
+  value: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+  onSend: PropTypes.func.isRequired,
+};

--- a/src/hooks/ChatRoadMap.jsx
+++ b/src/hooks/ChatRoadMap.jsx
@@ -1,0 +1,49 @@
+import { useState, useRef, useCallback } from 'react';
+import { useRoadmapWebSocket } from '../services/roadmapService.js';
+
+export function useChatRoadMap() {
+  const [messages, setMessages] = useState([]);
+  const [input, setInput] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [hasStarted, setHasStarted] = useState(false);
+  const messageContainerRef = useRef(null);
+
+  const handleWebSocketMessage = useCallback((msg) => {
+    setIsLoading(false);
+    if (typeof msg === 'object') {
+      setMessages(prev => [...prev, { role: 'agent', text: JSON.stringify(msg) }]);
+    } else {
+      setMessages(prev => [...prev, { role: 'agent', text: msg }]);
+    }
+  }, []);
+
+  const { connect, sendMessage } = useRoadmapWebSocket({
+    onMessage: handleWebSocketMessage,
+  });
+
+  const handleSend = useCallback(() => {
+    const text = input.trim();
+    if (!text) return;
+
+    setMessages(prev => [...prev, { role: 'user', text }]);
+    setInput('');
+    setIsLoading(true);
+
+    if (!hasStarted) {
+      connect();
+      setHasStarted(true);
+    }
+
+    sendMessage({ text, message_type: 'text' });
+  }, [input, connect, sendMessage, hasStarted]);
+
+  return {
+    messages,
+    input,
+    setInput,
+    handleSend,
+    isLoading,
+    hasStarted,
+    messageContainerRef,
+  };
+}

--- a/src/pages/ChatRoadmap.jsx
+++ b/src/pages/ChatRoadmap.jsx
@@ -1,104 +1,41 @@
-// import React, { useMemo, useCallback } from "react";
-// import {
-//   ROTATING_PROMPTS,
-//   BG_ICONS,
-//   useTypewriter
-// } from "./chatroadmapcomponents"
-// import { useRoadmapManager } from "./chatroadmapcomponents";
-// import { BackgroundIconCloud } from "./chatroadmapcomponents";
-// import { RoadmapDisplayView } from "./chatroadmapcomponents";
-// import { RoadmapChatView } from "./chatroadmapcomponents";
-// import { useWebSocketChat } from "./chatroadmapcomponents";
-// import { MessageList } from "./chatroadmapcomponents";
-
-// export default function ChatRoadmap() {
-
-//   const {
-//     existingRoadmap,
-//     roadmapLoading,
-//     chatDisabled,
-//     updateTopicInRoadmap,
-//     setRoadmapData,
-//     resetRoadmapData,
-//   } = useRoadmapManager();
-
-//   const {
-//     messages,
-//     input,
-//     setInput,
-//     isLoading,
-//     isFocused,
-//     setIsFocused,
-//     messageContainerRef,
-//     handleSend,
-//     resetChatState,
-//     hasMessages,
-//   } = useWebSocketChat({
-//     onTopicUpdate: updateTopicInRoadmap,
-//     onRoadmapCreate: setRoadmapData,
-//   });
-
-//   const typed = useTypewriter(ROTATING_PROMPTS, isFocused || input.length > 0);
-
-//   const resetChat = useCallback(async () => {
-//     await resetRoadmapData();
-//     resetChatState();
-//   }, [resetRoadmapData, resetChatState]);
-
-//   const icons = useMemo(() => BG_ICONS, []);
-
-//   return (
-//     <>
-//       <div className="relative w-full overflow-hidden min-h-screen text-slate-900 selection:bg-emerald-300/30 font-fraunces bg-white">
-
-//         <BackgroundIconCloud icons={icons} />
-
-//         {!roadmapLoading && existingRoadmap && (
-//           <RoadmapDisplayView
-//             existingRoadmap={existingRoadmap}
-//             onReset={resetChat}
-//           />
-//         )}
-
-//         {!roadmapLoading && !existingRoadmap && (
-//           <RoadmapChatView
-//             hasMessages={hasMessages}
-//             chatDisabled={chatDisabled}
-//             input={input}
-//             setInput={setInput}
-//             typed={typed}
-//             handleSend={handleSend}
-//             onReset={resetChat}
-//             isLoading={isLoading}
-//             setIsFocused={setIsFocused}
-//             messages={messages}
-//             messageContainerRef={messageContainerRef}
-//             MessageList={MessageList}
-//           />
-//         )}
-
-//       </div>
-//     </>
-//   );
-// }
-
-
 import { BackgroundIconCloud } from "../components/BackgroundIconCloud";
 import Navbar from "../components/Navbar";
-import RoadmapHeading from "../components/chatroadmap/RoadMapHeading";
+import RoadmapHeading from "../components/chatroadmap/RoadmapHeading";
 import TextAreaInput from "../components/chatroadmap/TextareaInput";
-import { ROTATING_PROMPTS } from "../components/chatroadmap";
+import { MessageList, ROTATING_PROMPTS } from "../components/chatroadmap";
+import { useChatRoadMap } from "../hooks/ChatRoadMap";
 
 export default function ChatRoadmap() {
+  const {
+    messages,
+    input,
+    setInput,
+    handleSend,
+    isLoading,
+    hasStarted,
+    messageContainerRef,
+  } = useChatRoadMap();
 
   return (
     <>
-    <Navbar/>
-    <BackgroundIconCloud />
-    <div className="flex-col font-fraunces px-[30px] lg:px-[250px]">
-      <RoadmapHeading />
-      <TextAreaInput prompts={ROTATING_PROMPTS}/> 
-    </div>
+      <Navbar />
+      <BackgroundIconCloud />
+      <div className="flex-col font-fraunces px-[30px] lg:px-[250px]">
+        {!hasStarted && <RoadmapHeading />}
+        {hasStarted && (
+          <MessageList
+            messages={messages}
+            isLoading={isLoading}
+            containerRef={messageContainerRef}
+          />
+        )}
+        <TextAreaInput
+          prompts={ROTATING_PROMPTS}
+          value={input}
+          onChange={setInput}
+          onSend={handleSend}
+        />
+      </div>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- Add `useChatRoadMap` hook to manage roadmap WebSocket messages
- Update text area input to expose send handler and support Enter key
- Render message list in chat page and hide heading once chat starts

## Testing
- `npm run lint` *(fails: 282 problems, 271 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b09e77d12c832f816f9b7fd2de37e2