### PR TITLE
Handle chat resets and store chat ID in hooks

### DIFF
--- a/src/components/chatroadmap/TextareaInput.jsx
+++ b/src/components/chatroadmap/TextareaInput.jsx
@@ -3,7 +3,7 @@ import { ArrowRight } from 'lucide-react';
 import PropTypes from 'prop-types';
 import { useTypewriter } from '../../hooks/useTypewriter';
 
-export default function TextAreaInput({ prompts = [], value = '', onChange, onSend }) {
+export default function TextAreaInput({ prompts = [], value = '', onChange, onSend, onReset }) {
   const hint = useTypewriter({ prompts });
 
   const handleKeyDown = (e) => {
@@ -47,12 +47,15 @@ export default function TextAreaInput({ prompts = [], value = '', onChange, onSe
         </div>
 
         {/* Restart button */}
-        <button
-          type="button"
-          className="text-xs font-medium bg-gradient-to-r from-[#0284c7] via-[#0ea5e9] to-[#22d3ee] bg-clip-text text-transparent hover:underline cursor-pointer"
-        >
-          + Start Again
-        </button>
+        {onReset && (
+          <button
+            type="button"
+            onClick={onReset}
+            className="text-xs font-medium bg-gradient-to-r from-[#0284c7] via-[#0ea5e9] to-[#22d3ee] bg-clip-text text-transparent hover:underline cursor-pointer"
+          >
+            + Start Again
+          </button>
+        )}
       </div>
     </div>
   );
@@ -63,4 +66,5 @@ TextAreaInput.propTypes = {
   value: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
   onSend: PropTypes.func.isRequired,
+  onReset: PropTypes.func,
 };

--- a/src/components/chatroadmap/useWebSocketChat.js
+++ b/src/components/chatroadmap/useWebSocketChat.js
@@ -19,6 +19,16 @@ export function useWebSocketChat({ onTopicUpdate, onRoadmapCreate }) {
   const handleWebSocketMessage = useCallback(async (msg) => {
     setIsLoading(false);
 
+    // Store chat id in localStorage for future messages
+    if (typeof msg === "object" && msg?.chat_id) {
+      try {
+        localStorage.setItem('chatRoadmapId', msg.chat_id);
+      } catch (e) {
+        console.warn('Failed to save chatRoadmapId to localStorage:', e);
+      }
+      return;
+    }
+
     if (typeof msg === "object" && msg && msg.topic_id && (msg.video_link || msg.assignment_links)) {
       const updates = {};
       if (msg.video_link) updates.video_link = msg.video_link;
@@ -145,7 +155,7 @@ export function useWebSocketChat({ onTopicUpdate, onRoadmapCreate }) {
 
   // Reset all chat state and close connections
   
-  const resetChatState = useCallback(() => {
+  const resetChat = useCallback(() => {
     setMessages([]);
     setInput('');
     setIsLoading(false);
@@ -186,7 +196,7 @@ export function useWebSocketChat({ onTopicUpdate, onRoadmapCreate }) {
     
     // Operations
     handleSend,
-    resetChatState,
+    resetChat,
     
     // Computed
     hasMessages: messages.length > 0,

--- a/src/hooks/ChatRoadMap.jsx
+++ b/src/hooks/ChatRoadMap.jsx
@@ -8,10 +8,21 @@ export function useChatRoadMap() {
 
   const handleWebSocketMessage = useCallback((msg) => {
     setIsLoading(false);
+
+    // Persist chat id for subsequent messages
+    if (typeof msg === 'object' && msg?.chat_id) {
+      try {
+        localStorage.setItem('chatRoadmapId', msg.chat_id);
+      } catch (e) {
+        console.warn('Failed to save chatRoadmapId to localStorage:', e);
+      }
+      return;
+    }
+
     if (typeof msg === 'object') {
-      setMessages(prev => [...prev, { role: 'agent', text: JSON.stringify(msg) }]);
+      setMessages((prev) => [...prev, { role: 'agent', text: JSON.stringify(msg) }]);
     } else {
-      setMessages(prev => [...prev, { role: 'agent', text: msg }]);
+      setMessages((prev) => [...prev, { role: 'agent', text: msg }]);
     }
   }, []);
 
@@ -39,11 +50,23 @@ export function useChatRoadMap() {
     setInput('');
   }, [input, messages, connect, sendMessage]);
 
+  const resetChat = useCallback(() => {
+    setMessages([]);
+    setInput('');
+    setIsLoading(false);
+    try {
+      localStorage.removeItem('chatRoadmapId');
+    } catch (e) {
+      console.warn('Failed to clear chatRoadmapId from localStorage:', e);
+    }
+  }, []);
+
   return {
     messages,
     input,
     setInput,
     handleSend,
     isLoading,
+    resetChat,
   };
 }

--- a/src/pages/ChatRoadmap.jsx
+++ b/src/pages/ChatRoadmap.jsx
@@ -12,6 +12,7 @@ export default function ChatRoadmap() {
     setInput,
     handleSend,
     isLoading,
+    resetChat,
   } = useChatRoadMap();
 
   return (
@@ -31,6 +32,7 @@ export default function ChatRoadmap() {
           value={input}
           onChange={setInput}
           onSend={handleSend}
+          onReset={messages.length > 0 ? resetChat : undefined}
         />
       </div>
     </>

--- a/src/services/roadmapService.js
+++ b/src/services/roadmapService.js
@@ -141,15 +141,6 @@ export function useRoadmapWebSocket({ onMessage } = {}) {
       try {
         const data = JSON.parse(event.data);
 
-        if (data?.chat_id) {
-          try {
-            localStorage.setItem('chatRoadmapId', data.chat_id);
-          } catch (e) {
-            console.warn('Failed to save chatRoadmapId to localStorage:', e);
-          }
-          return;
-        }
-
         if (data.token !== undefined) {
           onMessage?.(data.token);
         } else {


### PR DESCRIPTION
## Summary
- add `resetChat` hook logic to clear messages and chat ID
- capture chat ID in hook instead of roadmap service
- expose Start Again button to trigger chat reset

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: react/prop-types and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b4f92afc832f99f0075fb48c0bf7