### PR TITLE
feat: display roadmap analysis in chat history

### DIFF
--- a/src/services/roadmapService.js
+++ b/src/services/roadmapService.js
@@ -219,3 +219,30 @@ export async function fetchRoadmapMessages() {
     return [];
   }
 }
+
+export async function fetchRoadmapAnalysis() {
+  const { id: userId } = JSON.parse(localStorage.getItem('user') || '{}');
+  const chatId = localStorage.getItem('chatRoadmapId');
+
+  const fetchAnalysis = async (query) => {
+    const res = await fetch(`${API_BASE_URL}/roadmap_analysis?${query}`);
+    if (!res.ok) {
+      if (res.status === 404) return null;
+      throw new Error('Failed to fetch roadmap analysis');
+    }
+    const data = await res.json();
+    return data.roadmap;
+  };
+
+  if (userId) {
+    const roadmap = await fetchAnalysis(`user_id=${userId}`);
+    if (roadmap) return roadmap;
+  }
+
+  if (chatId) {
+    const roadmap = await fetchAnalysis(`chat_id=${chatId}`);
+    if (roadmap) return roadmap;
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- load roadmap analysis by user or chat id and append to chat history
- fetch roadmap analysis via new service and show in message list on load

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 236 problems)


------
https://chatgpt.com/codex/tasks/task_e_68b1801c900c832f949ed419fb9636fa