### PR TITLE
feat: add chat update service

### DIFF
--- a/src/services/chatService.js
+++ b/src/services/chatService.js
@@ -1,0 +1,34 @@
+import { API_BASE_URL } from '../config.js';
+
+function authHeaders() {
+  const token = localStorage.getItem('token');
+  const headers = { 'Content-Type': 'application/json' };
+  if (token) headers.Authorization = token;
+  return headers;
+}
+
+// Update chat when a chat ID exists in localStorage
+export async function updateChat(payload) {
+  const chatRoadmapId = localStorage.getItem('chatRoadmapId');
+  const chatId = localStorage.getItem('chatId');
+  const id = chatRoadmapId || chatId;
+  if (!id) return null;
+
+  const res = await fetch(`${API_BASE_URL}/chats/${id}`, {
+    method: 'PUT',
+    headers: authHeaders(),
+    body: JSON.stringify(payload),
+  });
+
+  const text = await res.text();
+  if (!res.ok) {
+    const err = new Error(`updateChat failed (${res.status}): ${text}`);
+    err.status = res.status;
+    err.body = text;
+    throw err;
+  }
+
+  const data = JSON.parse(text);
+  return data.chat;
+}
+


### PR DESCRIPTION
## Summary
- add chat service to update chat data when a chat ID exists in localStorage

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: prop-types etc.)

------
https://chatgpt.com/codex/tasks/task_e_68b18821b628832fad7adb8bae93de51