### PR TITLE
Link anonymous chat to user on login

### DIFF
--- a/src/components/LoginCard.jsx
+++ b/src/components/LoginCard.jsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import themeConfig from './themeConfig';
 import analytics from '../services/posthogService';
 import { API_BASE_URL } from '../config.js';
+import { updateChat } from '../services/chatService.js';
 import PropTypes from 'prop-types';
 
 const GOOGLE_CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID;
@@ -71,11 +72,20 @@ localStorage.setItem(
       );
       localStorage.setItem('token', appJwt);
 
-      window.dispatchEvent(new CustomEvent('userLoggedIn', { 
-        detail: { user: backendUser, token: appJwt } 
+      // If an anonymous chat exists, attach it to the logged-in user
+      const chatRoadmapId = localStorage.getItem('chatRoadmapId');
+      const chatId = localStorage.getItem('chatId');
+      if (chatRoadmapId || chatId) {
+        try {
+          await updateChat({ user_id: backendUser.id });
+        } catch (err) {
+          console.error('Failed to update chat with user', err);
+        }
+      }
+
+      window.dispatchEvent(new CustomEvent('userLoggedIn', {
+        detail: { user: backendUser, token: appJwt }
       }));
-
-
 
       window.location.reload();
   } catch (err) {

--- a/src/components/VerifyLearner.jsx
+++ b/src/components/VerifyLearner.jsx
@@ -3,6 +3,7 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import Navbar from './Navbar';
 import themeConfig from './themeConfig';
 import { API_BASE_URL } from '../config.js';
+import { updateChat } from '../services/chatService.js';
 
 export default function VerifyLearner() {
   const navigate = useNavigate();
@@ -53,6 +54,17 @@ export default function VerifyLearner() {
 
         localStorage.setItem('token', authToken);
         localStorage.setItem('user', JSON.stringify(user));
+
+        // If an anonymous chat exists, attach it to the logged-in user
+        const chatRoadmapId = localStorage.getItem('chatRoadmapId');
+        const chatId = localStorage.getItem('chatId');
+        if (chatRoadmapId || chatId) {
+          try {
+            await updateChat({ user_id: user.id });
+          } catch (err) {
+            console.error('Failed to update chat with user', err);
+          }
+        }
 
         // use replace so verification page doesn’t stay in history stack
         navigate(safeRedirect || '/platform', { replace: true });


### PR DESCRIPTION
## Summary
- Attach existing anonymous chat to user after successful Google login
- Update chat with user ID after magic-link verification

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 235 problems (226 errors, 9 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68b193a6e864832f93995c6abf9baa35