### PR TITLE
Delete roadmap on restart

### DIFF
--- a/src/services/roadmapService.js
+++ b/src/services/roadmapService.js
@@ -5,8 +5,9 @@ import { API_BASE_URL, WS_BASE_URL } from '../config.js';
 
 export const deleteRoadmap = async (roadmapId) => {
   try {
-    const roadmapId = localStorage.getItem('roadmapId');
-    const response = await fetch(`${API_BASE_URL}/roadmaps/${roadmapId}`, {
+    const id = roadmapId ?? localStorage.getItem('roadmapId');
+    if (!id) return;
+    const response = await fetch(`${API_BASE_URL}/roadmaps/${id}`, {
       method: 'DELETE',
     });
 
@@ -140,7 +141,7 @@ export async function fetchRoadmapAnalysis() {
   return null;
 }
 
-export const updateRoadmap = async (updates = {}) => {
+export const updateRoadmap = async (updates = {}, roadmapId) => {
   try {
     const id =
       roadmapId ??


### PR DESCRIPTION
## Summary
- delete any stored roadmap when restarting the chat
- expose roadmap deletion helper that accepts explicit id

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 229 errors, 9 warnings)
- `npx eslint src/hooks/ChatRoadMap.js src/services/roadmapService.js`

------
https://chatgpt.com/codex/tasks/task_e_68b1b93880f4832fa0ae3ff4fe26dbe5