### PR TITLE
Show roadmap UI on next week topics

### DIFF
--- a/src/components/chatroadmap/RoadMapUI.jsx
+++ b/src/components/chatroadmap/RoadMapUI.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import {
   ExternalLink,
   Clock,
@@ -96,7 +96,7 @@ const ResourceItem = ({ url, onClick }) => {
 };
 
 const YouTubeVideoCard = ({ url, title, onClick }) => {
-  const [videoTitle, setVideoTitle] = useState(title);
+  const [videoTitle] = useState(title);
   const thumbnailUrl = getYouTubeThumbnail(url);
 
   return (
@@ -136,7 +136,7 @@ const YouTubeVideoCard = ({ url, title, onClick }) => {
 };
 
 const RoadMapUI = ({ title, topics }) => {
-  const handleVideoClick = (videoLink, topicName) => {
+  const handleVideoClick = (videoLink) => {
     if (!videoLink) return;
     const url = `${window.location.origin}/study-room?video=${encodeURIComponent(videoLink)}&mode=play`;
     window.open(url, '_blank');
@@ -144,9 +144,10 @@ const RoadMapUI = ({ title, topics }) => {
 
   // Get week number from first topic (assuming all topics are from same week)
   const weekNumber = topics && topics.length > 0 ? topics[0].week_number : null;
+
+  const topicTypeLabel = (type) => {
     if (type === 'learning_video') return 'Video lecture';
-    if (type === 'question') return 'Assignment';
-    if (type === 'assignment') return 'Assignment';
+    if (type === 'question' || type === 'assignment') return 'Assignment';
     return null;
   };
 
@@ -154,9 +155,9 @@ const RoadMapUI = ({ title, topics }) => {
     window.open(resourceLink, '_blank');
   };
 
-  const topicTypeLabel = (type) => {
-  const sortedTopics = Array.isArray(topics) ? 
-    [...topics].sort((a, b) => a.topic_order - b.topic_order) : [];
+  const sortedTopics = Array.isArray(topics)
+    ? [...topics].sort((a, b) => a.topic_order - b.topic_order)
+    : [];
 
   return (
     <div className={themeConfig.roadmap.container}>

--- a/src/hooks/ChatRoadMap.js
+++ b/src/hooks/ChatRoadMap.js
@@ -12,6 +12,8 @@ export function useChatRoadMap() {
   const [input, setInput] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [isLoadingHistory, setIsLoadingHistory] = useState(false);
+  const [nextWeekTopics, setNextWeekTopics] = useState(null);
+  const [roadmapTitle, setRoadmapTitle] = useState('');
 
   useEffect(() => {
     const loadExistingMessages = async () => {
@@ -26,6 +28,7 @@ export function useChatRoadMap() {
           // If analysis exists, use its chat_id to fetch messages
           localStorage.setItem('roadmapId', analysis.id);
           localStorage.setItem('chatRoadmapId', analysis.chat_id);
+          setRoadmapTitle(analysis.title || '');
           
           const { id: userId } = JSON.parse(localStorage.getItem('user') || '{}');
           if ((analysis.user_id === null || analysis.user_id === undefined) && userId) {
@@ -79,6 +82,7 @@ export function useChatRoadMap() {
     }
 
     if (typeof data === "object" && data?.next_week_topics) {
+      setNextWeekTopics(data.next_week_topics);
       return;
     }
 
@@ -88,6 +92,9 @@ export function useChatRoadMap() {
         const { id: userId } = JSON.parse(localStorage.getItem('user') || '{}');
         if ((data.roadmap?.user_id === null || data.roadmap?.user_id === undefined) && userId) {
           updateRoadmap({ user_id: userId });
+        }
+        if (data.roadmap?.title) {
+          setRoadmapTitle(data.roadmap.title);
         }
         setMessages(prev => [
           ...prev,
@@ -156,6 +163,8 @@ export function useChatRoadMap() {
     setMessages([]);
     setInput('');
     setIsLoading(false);
+    setNextWeekTopics(null);
+    setRoadmapTitle('');
     const roadmapId = localStorage.getItem('roadmapId');
     if (roadmapId) {
       try {
@@ -184,6 +193,8 @@ export function useChatRoadMap() {
     isLoading,
     isLoadingHistory,
     resetChat,
+    nextWeekTopics,
+    roadmapTitle,
   };
 }
 

--- a/src/pages/ChatRoadmap.jsx
+++ b/src/pages/ChatRoadmap.jsx
@@ -16,7 +16,9 @@ export default function ChatRoadmap() {
     handleSend,
     isLoading,
     resetChat,
-    isLoadingHistory
+    isLoadingHistory,
+    nextWeekTopics,
+    roadmapTitle
   } = useChatRoadMap();
 
 
@@ -25,9 +27,13 @@ export default function ChatRoadmap() {
       <Navbar />
       <BackgroundIconCloud />
       <div className="relative z-10 flex-col font-fraunces px-[30px] lg:px-[250px]">
-        {messages.length === 0 && <RoadmapHeading />}
-        {messages.length > 0 && (
-          <MessageList messages={messages} isLoading={isLoading} />
+        {messages.length === 0 && !nextWeekTopics && <RoadmapHeading />}
+        {nextWeekTopics ? (
+          <RoadMapUI title={roadmapTitle} topics={nextWeekTopics} />
+        ) : (
+          messages.length > 0 && (
+            <MessageList messages={messages} isLoading={isLoading} />
+          )
         )}
         <TextAreaInput
           prompts={ROTATING_PROMPTS}
@@ -36,7 +42,7 @@ export default function ChatRoadmap() {
           onSend={handleSend}
           onReset={resetChat}
           isDisable={isLoadingHistory || isLoading}
-          floating={messages.length > 0}
+          floating={messages.length > 0 || !!nextWeekTopics}
         />
       </div>
     </>


### PR DESCRIPTION
## Summary
- Render roadmap UI when `next_week_topics` arrive via WebSocket and hide message list
- Track roadmap title from analysis and pass it along with topics to the UI
- Add state handling for next-week roadmap topics and roadmap title

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 221 errors, 9 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b3074de244832f8a4cc21fe79be0fd