### PR TITLE
Send create roadmap command via WebSocket

### DIFF
--- a/src/components/chatroadmap/MessageList.jsx
+++ b/src/components/chatroadmap/MessageList.jsx
@@ -5,7 +5,7 @@ import RoadmapAnalysis from "./RoadmapAnalysis";
 
 const FLOATING_FOOTER_PX = 130;
 
-export const MessageList = React.memo(function MessageList({ messages, isLoading }) {
+export const MessageList = React.memo(function MessageList({ messages, isLoading, onCreateRoadmap }) {
   const endRef = useRef(null);
   const bottomGap = FLOATING_FOOTER_PX;
 
@@ -31,7 +31,7 @@ export const MessageList = React.memo(function MessageList({ messages, isLoading
         if (isRoadmap) {
           return (
             <div key={idx} className="mr-auto w-full max-w-3xl">
-              <RoadmapAnalysis roadmap={msg.payload} />
+              <RoadmapAnalysis roadmap={msg.payload} onCreateRoadmap={onCreateRoadmap} />
             </div>
           );
         }

--- a/src/components/chatroadmap/RoadmapAnalysis.jsx
+++ b/src/components/chatroadmap/RoadmapAnalysis.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import themeConfig from "../themeConfig";
 
-export default function RoadmapAnalysis({ roadmap }) {
+export default function RoadmapAnalysis({ roadmap, onCreateRoadmap }) {
   const btn = themeConfig.buttons
   const skills = Array.isArray(roadmap?.skills_already_have)
     ? roadmap.skills_already_have
@@ -98,7 +98,10 @@ export default function RoadmapAnalysis({ roadmap }) {
 
         {/* Actions */}
         <div className="flex gap-4 pt-6">
-          <button className={`px-4 py-2 text-sm ${btn.secondary}`}>
+          <button
+            className={`px-4 py-2 text-sm ${btn.secondary}`}
+            onClick={onCreateRoadmap}
+          >
             Create roadmap
           </button>
         </div>

--- a/src/hooks/ChatRoadMap.js
+++ b/src/hooks/ChatRoadMap.js
@@ -159,6 +159,13 @@ export function useChatRoadMap() {
     setInput('');
   }, [input, messages, connect, sendMessage]);
 
+  const handleCreateRoadmap = useCallback(() => {
+    const text = 'create roadmap';
+    setIsLoading(true);
+    sendMessage({ text, message_type: 'text' });
+    setMessages(prev => [...prev, { role: 'user', text }]);
+  }, [sendMessage]);
+
   const resetChat = useCallback(async () => {
     setMessages([]);
     setInput('');
@@ -190,6 +197,7 @@ export function useChatRoadMap() {
     input,
     setInput,
     handleSend,
+    handleCreateRoadmap,
     isLoading,
     isLoadingHistory,
     resetChat,

--- a/src/pages/ChatRoadmap.jsx
+++ b/src/pages/ChatRoadmap.jsx
@@ -14,6 +14,7 @@ export default function ChatRoadmap() {
     input,
     setInput,
     handleSend,
+    handleCreateRoadmap,
     isLoading,
     resetChat,
     isLoadingHistory,
@@ -32,7 +33,11 @@ export default function ChatRoadmap() {
           <RoadMapUI title={roadmapTitle} topics={nextWeekTopics} />
         ) : (
           messages.length > 0 && (
-            <MessageList messages={messages} isLoading={isLoading} />
+            <MessageList
+              messages={messages}
+              isLoading={isLoading}
+              onCreateRoadmap={handleCreateRoadmap}
+            />
           )
         )}
         <TextAreaInput


### PR DESCRIPTION
## Summary
- allow RoadmapAnalysis to trigger roadmap creation via callback
- pass create roadmap action through MessageList and ChatRoadmap components
- send "create roadmap" over WebSocket and append user message when button clicked

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 223 errors, 9 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68b31d9b3dec832f88b09868ec3b0dff