### PR TITLE
feat: persist roadmap topics on refresh

### DIFF
--- a/src/hooks/ChatRoadMap.js
+++ b/src/hooks/ChatRoadMap.js
@@ -6,6 +6,7 @@ import {
   updateRoadmap,
   deleteRoadmap
 } from '../services/roadmapService.js';
+import { fetchActiveTopics } from '../services/topicService.js';
 
 export function useChatRoadMap() {
   const [messages, setMessages] = useState([]);
@@ -54,6 +55,15 @@ export function useChatRoadMap() {
         
         if (merged.length > 0) {
           setMessages(merged);
+        }
+
+        // Fetch active topics for the existing roadmap, if any
+        const roadmapId = analysis?.id ?? parseInt(localStorage.getItem('roadmapId') || '', 10);
+        if (roadmapId) {
+          const topics = await fetchActiveTopics(roadmapId);
+          if (topics.length > 0) {
+            setNextWeekTopics(topics);
+          }
         }
       } catch (error) {
         console.error('Failed to load existing messages:', error);

--- a/src/services/topicService.js
+++ b/src/services/topicService.js
@@ -1,0 +1,19 @@
+import { API_BASE_URL } from '../config.js';
+
+export async function fetchActiveTopics(roadmapId) {
+  try {
+    const id = roadmapId ?? parseInt(localStorage.getItem('roadmapId') || '', 10);
+    if (!id || Number.isNaN(id)) {
+      return [];
+    }
+    const response = await fetch(`${API_BASE_URL}/topics?roadmap_id=${id}`);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch topics: ${response.status}`);
+    }
+    const data = await response.json();
+    return data.topics || [];
+  } catch (error) {
+    console.error('Error fetching active topics:', error);
+    return [];
+  }
+}


### PR DESCRIPTION
## Summary
- add topic service to fetch active topics
- load active topics when ChatRoadmap mounts

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: many prop-types errors)

------
https://chatgpt.com/codex/tasks/task_e_68b32aad3c10832fb2bfd4bf72a2b84b