### PR TITLE
Display next modules in roadmap UI

### DIFF
--- a/src/components/chatroadmap/RoadMapUI.jsx
+++ b/src/components/chatroadmap/RoadMapUI.jsx
@@ -466,9 +466,9 @@ const YouTubeVideoCard = ({ url, title, onClick }) => {
   );
 };
 
-// Future Topics Component
-const FutureTopicsCard = ({ futureTopics }) => {
-  if (!Array.isArray(futureTopics) || futureTopics.length === 0) {
+// Next Modules Component
+const NextModulesCard = ({ nextModules }) => {
+  if (!Array.isArray(nextModules) || nextModules.length === 0) {
     return null;
   }
 
@@ -487,7 +487,7 @@ const FutureTopicsCard = ({ futureTopics }) => {
               </span>
             </h2>
             <div className="bg-gradient-to-r from-indigo-100 to-purple-100 text-indigo-700 px-4 py-2 rounded-full text-sm font-semibold shadow-md border border-indigo-200/50">
-              {futureTopics.length} Modules
+              {nextModules.length} Modules
             </div>
           </div>
         </div>
@@ -495,9 +495,9 @@ const FutureTopicsCard = ({ futureTopics }) => {
         {/* Content */}
         <div className="p-4 sm:p-6">
           <div className="grid gap-4">
-            {futureTopics.map((topicName, index) => (
+            {nextModules.map((module, index) => (
               <div
-                key={`future-topic-${index}`}
+                key={`next-module-${index}`}
                 className="bg-gradient-to-r from-white/90 to-white/80 backdrop-blur-lg border border-white/40 rounded-2xl p-4 sm:p-5 transition-all duration-300 hover:shadow-lg hover:border-white/60 group"
               >
                 <div className="flex items-center gap-4">
@@ -508,10 +508,10 @@ const FutureTopicsCard = ({ futureTopics }) => {
                     </span>
                   </div>
 
-                  {/* Topic Content */}
+                  {/* Module Content */}
                   <div className="flex-1 min-w-0">
                     <h3 className="text-base sm:text-lg font-semibold text-slate-900 leading-tight group-hover:text-indigo-700 transition-colors duration-200">
-                      {topicName}
+                      {module?.ModuleName || module?.module_name || module}
                     </h3>
                   </div>
 
@@ -529,7 +529,7 @@ const FutureTopicsCard = ({ futureTopics }) => {
   );
 };
 
-const RoadMapUI = ({ title, topics, futureTopics }) => {
+const RoadMapUI = ({ title, topics, nextModules }) => {
   const handleVideoClick = (videoLink) => {
     if (!videoLink) return;
     const url = `${window.location.origin}/study-room?video=${encodeURIComponent(videoLink)}&mode=play`;
@@ -702,8 +702,8 @@ const RoadMapUI = ({ title, topics, futureTopics }) => {
         </div>
       </div>
 
-      {/* Future Topics Section */}
-      <FutureTopicsCard futureTopics={futureTopics} />
+      {/* Next Modules Section */}
+      <NextModulesCard nextModules={nextModules} />
     </div>
   );
 };

--- a/src/hooks/ChatRoadMap.js
+++ b/src/hooks/ChatRoadMap.js
@@ -14,6 +14,7 @@ export function useChatRoadMap() {
   const [isLoading, setIsLoading] = useState(false);
   const [isLoadingHistory, setIsLoadingHistory] = useState(false);
   const [nextWeekTopics, setNextWeekTopics] = useState(null);
+  const [nextModules, setNextModules] = useState([]);
   const [roadmapTitle, setRoadmapTitle] = useState('');
 
   useEffect(() => {
@@ -30,6 +31,9 @@ export function useChatRoadMap() {
           localStorage.setItem('roadmapId', analysis.id);
           localStorage.setItem('chatRoadmapId', analysis.chat_id);
           setRoadmapTitle(analysis.title || '');
+          if (Array.isArray(analysis.next_modules)) {
+            setNextModules(analysis.next_modules);
+          }
           
           const { id: userId } = JSON.parse(localStorage.getItem('user') || '{}');
           if ((analysis.user_id === null || analysis.user_id === undefined) && userId) {
@@ -107,6 +111,9 @@ export function useChatRoadMap() {
         if (data.roadmap?.title) {
           setRoadmapTitle(data.roadmap.title);
         }
+        if (Array.isArray(data.roadmap?.next_modules)) {
+          setNextModules(data.roadmap.next_modules);
+        }
         setMessages(prev => [
           ...prev,
           {
@@ -182,6 +189,7 @@ export function useChatRoadMap() {
     setInput('');
     setIsLoading(false);
     setNextWeekTopics(null);
+    setNextModules([]);
     setRoadmapTitle('');
     const roadmapId = localStorage.getItem('roadmapId');
     if (roadmapId) {
@@ -213,6 +221,7 @@ export function useChatRoadMap() {
     isLoadingHistory,
     resetChat,
     nextWeekTopics,
+    nextModules,
     roadmapTitle,
   };
 }

--- a/src/pages/ChatRoadmap.jsx
+++ b/src/pages/ChatRoadmap.jsx
@@ -19,6 +19,7 @@ export default function ChatRoadmap() {
     resetChat,
     isLoadingHistory,
     nextWeekTopics,
+    nextModules,
     roadmapTitle
   } = useChatRoadMap();
 
@@ -30,7 +31,7 @@ export default function ChatRoadmap() {
       <div className="relative z-10 flex-col font-fraunces px-[30px] lg:px-[250px]">
         {messages.length === 0 && !nextWeekTopics && <RoadmapHeading />}
         {nextWeekTopics ? (
-          <RoadMapUI title={roadmapTitle} topics={nextWeekTopics} />
+          <RoadMapUI title={roadmapTitle} topics={nextWeekTopics} nextModules={nextModules} />
         ) : (
           messages.length > 0 && (
             <MessageList


### PR DESCRIPTION
## Summary
- Capture `next_modules` from roadmap websocket messages
- Show upcoming modules in `RoadMapUI`
- Rename future topic variables to `nextModules`/`ModuleName`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: PropTypes warnings and lint errors in unrelated files)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b34f213308832faf9da11bb350922a