### PR TITLE
feat: show roadmap reset and weekly plan updates

### DIFF
--- a/src/components/chatroadmap/RoadMapUI.jsx
+++ b/src/components/chatroadmap/RoadMapUI.jsx
@@ -10,6 +10,7 @@ import {
   ChevronUp,
   Lock
 } from 'lucide-react';
+import TextAreaInput from "./TextareaInput";
 
 // Utility functions
 const getYouTubeVideoId = (url) => {
@@ -148,7 +149,8 @@ const YouTubeVideoCard = ({ url, title, onClick }) => {
 // Topic Dropdown Component
 const TopicsDropdown = ({ topics, weekNumber, handleVideoClick, handleResourceClick }) => {
   const [isExpanded, setIsExpanded] = useState(true);
-  
+  const [weeklyPlan, setWeeklyPlan] = useState('');
+
   const sortedTopics = Array.isArray(topics)
     ? [...topics].sort((a, b) => a.topic_order - b.topic_order)
     : [];
@@ -313,6 +315,21 @@ const TopicsDropdown = ({ topics, weekNumber, handleVideoClick, handleResourceCl
               </div>
             </div>
           ))}
+
+          {/* Update Weekly Plan textarea */}
+          <div>
+            <h4 className="font-bold text-slate-800 mb-4">Update Weekly Plan:</h4>
+            <TextAreaInput
+              prompts={["Update your weekly plan..."]}
+              value={weeklyPlan}
+              onChange={setWeeklyPlan}
+              onSend={() => {}}
+              isDisable={false}
+              floating={false}
+              showReset={false}
+              rows={2}
+            />
+          </div>
         </div>
       )}
     </div>

--- a/src/components/chatroadmap/TextareaInput.jsx
+++ b/src/components/chatroadmap/TextareaInput.jsx
@@ -3,7 +3,7 @@ import { ArrowRight } from 'lucide-react';
 import PropTypes from 'prop-types';
 import { useTypewriter } from '../../hooks/useTypewriter';
 
-export default function TextAreaInput({ prompts = [], value = '', onChange, onSend, onReset, isDisable, floating = false }) {
+export default function TextAreaInput({ prompts = [], value = '', onChange, onSend, onReset, isDisable, floating = false, showReset = true, rows = 3 }) {
   const hint = useTypewriter({ prompts });
 
   const handleKeyDown = (e) => {
@@ -28,7 +28,7 @@ export default function TextAreaInput({ prompts = [], value = '', onChange, onSe
         )}
 
         <textarea
-          rows={3}
+          rows={rows}
           value={value}
           onChange={(e) => onChange?.(e.target.value)}
           onKeyDown={handleKeyDown}
@@ -51,7 +51,8 @@ export default function TextAreaInput({ prompts = [], value = '', onChange, onSe
         </div>
 
         {/* Restart button */}
-        
+
+        {showReset && (
         <button
         type="button"
         onClick={onReset}
@@ -59,6 +60,7 @@ export default function TextAreaInput({ prompts = [], value = '', onChange, onSe
         >
         + Start Again
         </button>
+        )}
       </div>
     </div>
   );
@@ -70,4 +72,6 @@ TextAreaInput.propTypes = {
   onChange: PropTypes.func.isRequired,
   onSend: PropTypes.func.isRequired,
   onReset: PropTypes.func,
+  showReset: PropTypes.bool,
+  rows: PropTypes.number,
 };

--- a/src/pages/ChatRoadmap.jsx
+++ b/src/pages/ChatRoadmap.jsx
@@ -40,25 +40,38 @@ export default function ChatRoadmap() {
       <div className="relative z-10 flex-col font-fraunces px-[30px] lg:px-[250px]">
         {messages.length === 0 && !nextWeekTopics && <RoadmapHeading />}
         {nextWeekTopics ? (
-          <RoadMapUI title={roadmapTitle} topics={nextWeekTopics} nextModules={nextModules} />
+          <>
+            <RoadMapUI title={roadmapTitle} topics={nextWeekTopics} nextModules={nextModules} />
+            <div className="fixed inset-x-0 bottom-6 mx-[30px] lg:mx-[250px]">
+              <button
+                type="button"
+                onClick={resetChat}
+                className="w-full py-3 bg-gradient-to-r from-[#0284c7] via-[#0ea5e9] to-[#22d3ee] hover:from-[#0369a1] hover:to-[#06b6d4] text-white font-semibold rounded-xl shadow-sm"
+              >
+                Create Roadmap Again
+              </button>
+            </div>
+          </>
         ) : (
-          messages.length > 0 && (
-            <MessageList
-              messages={messages}
-              isLoading={isLoading}
-              onCreateRoadmap={handleCreateRoadmap}
+          <>
+            {messages.length > 0 && (
+              <MessageList
+                messages={messages}
+                isLoading={isLoading}
+                onCreateRoadmap={handleCreateRoadmap}
+              />
+            )}
+            <TextAreaInput
+              prompts={ROTATING_PROMPTS}
+              value={input}
+              onChange={setInput}
+              onSend={handleSend}
+              onReset={resetChat}
+              isDisable={isLoadingHistory || isLoading}
+              floating={messages.length > 0}
             />
-          )
+          </>
         )}
-        <TextAreaInput
-          prompts={ROTATING_PROMPTS}
-          value={input}
-          onChange={setInput}
-          onSend={handleSend}
-          onReset={resetChat}
-          isDisable={isLoadingHistory || isLoading}
-          floating={messages.length > 0 || !!nextWeekTopics}
-        />
       </div>
     </>
   );


### PR DESCRIPTION
## Summary
- hide chat input when roadmap is displayed and show sticky "Create Roadmap Again" reset button
- allow TextAreaInput to hide restart link and reuse it inside roadmap
- add weekly plan textarea within roadmap topics dropdown for future updates
- support custom textarea rows and default to two rows in the roadmap weekly plan

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 243 problems: 234 errors, 9 warnings)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b438a7487c832fbb8d47db5b0ab62a