### PR TITLE
Adjust ChatRoadmap input flow

### DIFF
--- a/src/components/chatroadmap/RoadMapUI.jsx
+++ b/src/components/chatroadmap/RoadMapUI.jsx
@@ -10,7 +10,6 @@ import {
   ChevronUp,
   Lock
 } from 'lucide-react';
-import TextAreaInput from "./TextareaInput";
 
 // Utility functions
 const getYouTubeVideoId = (url) => {
@@ -149,7 +148,6 @@ const YouTubeVideoCard = ({ url, title, onClick }) => {
 // Topic Dropdown Component
 const TopicsDropdown = ({ topics, weekNumber, handleVideoClick, handleResourceClick }) => {
   const [isExpanded, setIsExpanded] = useState(true);
-  const [weeklyPlan, setWeeklyPlan] = useState('');
 
   const sortedTopics = Array.isArray(topics)
     ? [...topics].sort((a, b) => a.topic_order - b.topic_order)
@@ -315,21 +313,6 @@ const TopicsDropdown = ({ topics, weekNumber, handleVideoClick, handleResourceCl
               </div>
             </div>
           ))}
-
-          {/* Update Weekly Plan textarea */}
-          <div>
-            <h4 className="font-bold text-slate-800 mb-4">Update Weekly Plan:</h4>
-            <TextAreaInput
-              prompts={["Update your weekly plan..."]}
-              value={weeklyPlan}
-              onChange={setWeeklyPlan}
-              onSend={() => {}}
-              isDisable={false}
-              floating={false}
-              showReset={false}
-              rows={2}
-            />
-          </div>
         </div>
       )}
     </div>

--- a/src/hooks/ChatRoadMap.js
+++ b/src/hooks/ChatRoadMap.js
@@ -7,6 +7,7 @@ import {
   deleteRoadmap
 } from '../services/roadmapService.js';
 import { fetchActiveTopics } from '../services/topicService.js';
+import { API_BASE_URL } from '../config.js';
 
 export function useChatRoadMap() {
   const [messages, setMessages] = useState([]);
@@ -184,6 +185,26 @@ export function useChatRoadMap() {
     setMessages(prev => [...prev, { role: 'user', text }]);
   }, [sendMessage]);
 
+  const handleFollowUp = useCallback(async () => {
+    const text = input.trim();
+    if (!text) return;
+
+    setIsLoading(true);
+    try {
+      const chatId = localStorage.getItem('chatRoadmapId');
+      await fetch(`${API_BASE_URL}/roadmaps/followup`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text, chat_id: chatId ? parseInt(chatId, 10) : null }),
+      });
+    } catch (error) {
+      console.error('Failed to send follow-up:', error);
+    } finally {
+      setIsLoading(false);
+      setInput('');
+    }
+  }, [input]);
+
   const resetChat = useCallback(async () => {
     setMessages([]);
     setInput('');
@@ -217,6 +238,7 @@ export function useChatRoadMap() {
     setInput,
     handleSend,
     handleCreateRoadmap,
+    handleFollowUp,
     isLoading,
     isLoadingHistory,
     resetChat,

--- a/src/pages/ChatRoadmap.jsx
+++ b/src/pages/ChatRoadmap.jsx
@@ -17,6 +17,7 @@ export default function ChatRoadmap() {
     setInput,
     handleSend,
     handleCreateRoadmap,
+    handleFollowUp,
     isLoading,
     resetChat,
     isLoadingHistory,
@@ -42,15 +43,15 @@ export default function ChatRoadmap() {
         {nextWeekTopics ? (
           <>
             <RoadMapUI title={roadmapTitle} topics={nextWeekTopics} nextModules={nextModules} />
-            <div className="fixed inset-x-0 bottom-6 mx-[30px] lg:mx-[250px]">
-              <button
-                type="button"
-                onClick={resetChat}
-                className="w-full py-3 bg-gradient-to-r from-[#0284c7] via-[#0ea5e9] to-[#22d3ee] hover:from-[#0369a1] hover:to-[#06b6d4] text-white font-semibold rounded-xl shadow-sm"
-              >
-                Create Roadmap Again
-              </button>
-            </div>
+            <TextAreaInput
+              prompts={ROTATING_PROMPTS}
+              value={input}
+              onChange={setInput}
+              onSend={handleFollowUp}
+              onReset={resetChat}
+              isDisable={isLoadingHistory || isLoading}
+              floating={true}
+            />
           </>
         ) : (
           <>


### PR DESCRIPTION
## Summary
- support follow-up requests via new API call
- keep chat textarea after roadmap display and drop reset button
- remove unused weekly plan textarea from roadmap UI

## Testing
- `npm run lint` *(fails: 234 errors, 9 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b43fa50edc832f86e7a283fde9478e