### PR TITLE
Add loading state for topic updates

### DIFF
--- a/src/pages/ChatRoadmap.jsx
+++ b/src/pages/ChatRoadmap.jsx
@@ -21,6 +21,7 @@ export default function ChatRoadmap() {
     isLoading,
     resetChat,
     isLoadingHistory,
+    isUpdatingTopics,
     nextWeekTopics,
     nextModules,
     roadmapTitle
@@ -42,14 +43,19 @@ export default function ChatRoadmap() {
         {messages.length === 0 && !nextWeekTopics && <RoadmapHeading />}
         {nextWeekTopics ? (
           <>
-            <RoadMapUI title={roadmapTitle} topics={nextWeekTopics} nextModules={nextModules} />
+            <RoadMapUI
+              title={roadmapTitle}
+              topics={nextWeekTopics}
+              nextModules={nextModules}
+              isLoadingTopics={isUpdatingTopics}
+            />
             <TextAreaInput
               prompts={FOLLOW_UP_PROMPTS}
               value={input}
               onChange={setInput}
               onSend={handleFollowUp}
               onReset={resetChat}
-              isDisable={isLoadingHistory || isLoading}
+              isDisable={isLoadingHistory || isLoading || isUpdatingTopics}
               floating={true}
             />
           </>


### PR DESCRIPTION
## Summary
- disable follow-up textbox and show skeleton while updating roadmap topics
- update roadmap topics from API response and avoid chat loading dots

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 236 errors, 9 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b44f315d9c832fb3fbc6c0908d5cb3