### PR TITLE
Handle video link updates via websocket

### DIFF
--- a/src/hooks/ChatRoadMap.js
+++ b/src/hooks/ChatRoadMap.js
@@ -126,7 +126,20 @@ export function useChatRoadMap() {
         ]);
       } catch { /* ignore */ }
     }
-  
+
+    if (typeof data === "object" && data?.topic_id && data?.video_link) {
+      setNextWeekTopics(prev => {
+        if (!Array.isArray(prev)) return prev;
+        return prev.map(topic => {
+          const id = topic.id ?? topic.topic_id;
+          return id === data.topic_id
+            ? { ...topic, video_link: data.video_link }
+            : topic;
+        });
+      });
+      return;
+    }
+
     // 2) Full message → add as agent
     if (typeof data === "object" && data?.message !== undefined) {
       setMessages(prev => [...prev, { role: "agent", kind: "text", text: String(data.message) }]);


### PR DESCRIPTION
## Summary
- Update ChatRoadMap hook to process `topic_id` + `video_link` WebSocket messages
- Update roadmap state so specific topics display new video links

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: React/JS lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b59f27c6d0832fb29e751748bda0a8