### PR TITLE
Add short lesson page with navigation from roadmap

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import {
 import PrivacyPolicy from './pages/PrivacyPolicy';
 import GoogleLogin from './pages/LoginPage';
 import StartLearningPage from './pages/StartLearningPage';
+import ShortLessonPage from './pages/ShortLessonPage';
 
 
 export default function App() {
@@ -63,6 +64,8 @@ function AppRoutes() {
         path="/learn-now"
         element={<StartLearningPage />}
       />
+
+      <Route path="/short-lesson/:miniLesson" element={<ShortLessonPage />} />
 
       {/* Fallback */}
       <Route

--- a/src/components/startLearning/RoadmapRecommendation.jsx
+++ b/src/components/startLearning/RoadmapRecommendation.jsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { BookOpen, Info, ChevronRight, Target, Play, CheckCircle, Clock } from 'lucide-react';
 
 const RoadmapComponent = ({ data }) => {
@@ -9,6 +10,7 @@ const RoadmapComponent = ({ data }) => {
 
   const [hoveredTopic, setHoveredTopic] = useState(null);
   const [completedTopics, setCompletedTopics] = useState(new Set());
+  const navigate = useNavigate();
 
   // --- NEW: small helper to ensure we display the proper lesson title
   const getLessonTitle = (lesson, fallback) => {
@@ -18,10 +20,11 @@ const RoadmapComponent = ({ data }) => {
     return fallback ?? '';
   };
 
-  const handleTopicClick = (topicIndex) => {
+  const handleTopicClick = (topic, topicIndex) => {
     const next = new Set(completedTopics);
     next.has(topicIndex) ? next.delete(topicIndex) : next.add(topicIndex);
     setCompletedTopics(next);
+    navigate(`/short-lesson/${encodeURIComponent(topic)}`);
   };
 
   return (
@@ -85,7 +88,7 @@ const RoadmapComponent = ({ data }) => {
                           <button
                             type="button"
                             key={topicIndex}
-                            onClick={() => handleTopicClick(topicIndex)}
+                            onClick={() => handleTopicClick(topic, topicIndex)}
                             onMouseEnter={() => setHoveredTopic(topicIndex)}
                             onMouseLeave={() => setHoveredTopic(null)}
                             className={`group w-full text-left bg-white border rounded-lg shadow-sm hover:shadow-md focus:shadow-md transition-all duration-200 overflow-hidden cursor-pointer focus:outline-none focus:ring-2 focus:ring-indigo-400 transform hover:scale-[1.01] ${

--- a/src/pages/ShortLessonPage.jsx
+++ b/src/pages/ShortLessonPage.jsx
@@ -1,0 +1,16 @@
+import Navbar from '../components/navbar/Navbar';
+import { useParams } from 'react-router-dom';
+
+export default function ShortLessonPage() {
+  const { miniLesson } = useParams();
+  const lessonName = decodeURIComponent(miniLesson);
+
+  return (
+    <>
+      <Navbar />
+      <div className="p-4">
+        <h1 className="text-2xl font-bold">{lessonName}</h1>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- navigate to short lesson pages when a mini lesson is clicked in roadmap recommendations
- add `/short-lesson/:miniLesson` route and page to show the selected mini lesson name

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 70 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c00dfb9914832fa26bd42296ec93ba