### PR TITLE
feat: show spinner while preparing short lesson

### DIFF
--- a/src/components/Loader.jsx
+++ b/src/components/Loader.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+export default function Loader({ text = 'Preparing your interactive lesson...' }) {
+  return (
+    <div className="flex flex-col items-center gap-3 text-gray-600">
+      <svg
+        className="h-6 w-6 animate-spin text-blue-500"
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+      >
+        <circle
+          className="opacity-25"
+          cx="12"
+          cy="12"
+          r="10"
+          stroke="currentColor"
+          strokeWidth="4"
+        />
+        <path
+          className="opacity-75"
+          fill="currentColor"
+          d="M4 12a8 8 0 018-8v4l3-3-3-3v4a8 8 0 00-8 8h4z"
+        />
+      </svg>
+      <p>{text}</p>
+    </div>
+  );
+}

--- a/src/pages/ShortLessonPage.jsx
+++ b/src/pages/ShortLessonPage.jsx
@@ -1,6 +1,7 @@
 import React, { Suspense, useState, useEffect, useCallback } from 'react';
 import { useParams, useLocation } from 'react-router-dom';
 import Navbar from '../components/navbar/Navbar';
+import Loader from '../components/Loader';
 import { useShortLesson } from '../hooks/useShortLesson';
 
 // ---------- Error Boundary ----------
@@ -219,8 +220,8 @@ export default function ShortLessonPage() {
     return (
       <div className="lesson-page-container min-h-[100dvh] w-[100dvw] max-w-[100dvw] flex flex-col overflow-x-hidden">
         <Navbar />
-        <div className="flex-1 min-h-0 min-w-0 flex items-center justify-center text-gray-600">
-          Preparing your lesson…
+        <div className="flex-1 min-h-0 min-w-0 flex items-center justify-center">
+          <Loader />
         </div>
       </div>
     );


### PR DESCRIPTION
## Summary
- add reusable `Loader` component with spinner and message
- use `Loader` in `ShortLessonPage` while lesson data loads

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 76 problems)


------
https://chatgpt.com/codex/tasks/task_e_68c410689060832f90986d35143e1667