### PR TITLE
Load stored discussion history for mini lesson chat

### DIFF
--- a/src/pages/StartLearningPage.jsx
+++ b/src/pages/StartLearningPage.jsx
@@ -13,8 +13,13 @@ export default function StartLearningPage() {
 
   const { messages, isAwaitingResponse, startLearning, reset , roadmapStatus  , RoadmapStatusCheck , roadmapData} = useStartLearning();
   
-  useEffect( () => {
-    RoadmapStatusCheck();  
+  useEffect(() => {
+    RoadmapStatusCheck();
+    try {
+      localStorage.removeItem('chatDiscussionID');
+    } catch (_) {
+      // Ignore storage errors
+    }
   }, []);
 
   const handleSend = () => {


### PR DESCRIPTION
## Summary
- load existing mini-lesson discussion history using the stored chat discussion id when the panel is opened
- expose the useMiniLessonDiscussion hook alias and track history loading state for the discussion UI
- clear the stored chat discussion id when the learn/start learning page mounts

## Testing
- npm run lint *(fails: existing lint errors in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68c95c7919e4832fad5c8f55641c05aa