### PR TITLE
Prefetch next mini lesson material when starting discussion

### DIFF
--- a/src/components/startLearning/RoadmapRecommendation.jsx
+++ b/src/components/startLearning/RoadmapRecommendation.jsx
@@ -73,8 +73,25 @@ export default function RoadmapComponent({ message }) {
       return;
     }
 
+    const miniLessonsList = Array.isArray(currentLesson?.mini_lessons)
+      ? currentLesson.mini_lessons
+      : [];
+
+    const navigationState =
+      selectedMiniLesson && typeof selectedMiniLesson === 'object'
+        ? { ...selectedMiniLesson }
+        : {};
+
+    if (!navigationState.name) {
+      navigationState.name = selectedMiniLesson?.name || fallbackName;
+    }
+
     navigate(targetUrl, {
-      state: selectedMiniLesson
+      state: {
+        ...navigationState,
+        miniLessons: miniLessonsList,
+        miniLessonIndex,
+      }
     });
   };
 


### PR DESCRIPTION
## Summary
- include the lesson's mini-lesson list and active index in the navigation state when launching a lesson
- fire-and-forget the create-material request for the next mini lesson when the discussion is opened so it is ready in advance

## Testing
- npm run lint *(fails: existing repository lint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68c98070ca40832f8c65cd4618d628c4