### PR TITLE
Simplify short lesson embed for Vercel mini lessons

### DIFF
--- a/src/pages/ShortLessonPage.jsx
+++ b/src/pages/ShortLessonPage.jsx
@@ -1,34 +1,38 @@
-import React, { useCallback } from 'react';
-import { useParams, useLocation, useNavigate } from 'react-router-dom';
+import { useCallback } from 'react';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import Navbar from '../components/navbar/Navbar';
 import LessonHeader from '../components/lesson/LessonHeader';
+import { useShortLesson } from '../hooks/useShortLesson';
 
-// Minimal page that only shows the lesson name, a "Start Discussion" button,
-// and an iframe that embeds a remote app (e.g., a Vercel URL).
-// Pass a custom URL with the query param `?src=...` if needed.
+function formatLessonName(slug, fallback) {
+  if (!slug) {
+    return fallback;
+  }
+
+  return slug
+    .split('-')
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(' ');
+}
 
 export default function ShortLessonPage() {
   const { id, miniLessonSlug } = useParams();
-  const location = useLocation();
+  const { state } = useLocation();
   const navigate = useNavigate();
-  const { search, state } = location;
 
-  // Human‑readable lesson title from slug or route state
-  const lessonDisplayName = miniLessonSlug
-    ? miniLessonSlug.replace(/-/g, ' ').replace(/\b\w/g, (l) => l.toUpperCase())
-    : state?.name || 'Interactive Lesson';
+  const lessonDisplayName = state?.name || formatLessonName(miniLessonSlug, 'Interactive Lesson');
+  const miniLessonId = state?.id ?? state?.mini_lesson_id ?? id;
 
-  // Allow overriding the iframe URL via `?src=`; otherwise default to your Vercel link
-  const params = new URLSearchParams(search);
-  const iframeSrc = params.get('src') || 'https://left-join33-l6k4bzdh2-ilon-ais-projects.vercel.app';
+  const { lessonUrl, loading, error } = useShortLesson(miniLessonId);
 
   const handleStartDiscussion = useCallback(() => {
     if (!id || !miniLessonSlug) return;
-    navigate(`/${id}/${miniLessonSlug}/topic-discussion${search || ''}`, {
+
+    navigate(`/${id}/${miniLessonSlug}/topic-discussion`, {
       state,
       replace: false,
     });
-  }, [id, miniLessonSlug, navigate, search, state]);
+  }, [id, miniLessonSlug, navigate, state]);
 
   return (
     <div className="lesson-page-container min-h-[100dvh] w-[100dvw] max-w-[100dvw] flex flex-col overflow-x-hidden">
@@ -42,17 +46,49 @@ export default function ShortLessonPage() {
         />
 
         <div className="mt-4 flex-1 min-h-0">
-          {/* IFRAME EMBED */}
-          <div className="w-full h-full border border-gray-200 rounded-lg overflow-hidden bg-white">
-            <iframe
-              src={iframeSrc}
-              title={lessonDisplayName}
-              className="w-full h-[80vh]"
-              loading="lazy"
-              allow="fullscreen; clipboard-read; clipboard-write; accelerometer; gyroscope"
-              // NOTE: Do not set a restrictive sandbox if the remote app needs scripts/cookies.
-              // sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-downloads"
-            />
+          <div className="w-full h-full border border-gray-200 rounded-lg overflow-hidden bg-white flex flex-col">
+            {loading ? (
+              <div className="flex-1 flex flex-col items-center justify-center gap-2 text-slate-600">
+                <span className="text-sm font-medium">Preparing your mini lesson…</span>
+                <span className="text-xs text-slate-400">This may take a few seconds.</span>
+              </div>
+            ) : error ? (
+              <div className="flex-1 flex items-center justify-center p-6">
+                <div className="text-center">
+                  <p className="text-sm font-semibold text-red-600">Unable to load the mini lesson.</p>
+                  <p className="mt-2 text-xs text-red-500 break-words max-w-md mx-auto">{error}</p>
+                </div>
+              </div>
+            ) : lessonUrl ? (
+              <>
+                <div className="flex items-center justify-between gap-3 border-b border-gray-200 bg-gray-50 px-4 py-2">
+                  <span className="truncate text-xs text-slate-500" title={lessonUrl}>
+                    {lessonUrl}
+                  </span>
+                  <a
+                    href={lessonUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-xs font-medium text-indigo-600 hover:text-indigo-700 hover:underline"
+                  >
+                    Open in new tab
+                  </a>
+                </div>
+                <iframe
+                  key={lessonUrl}
+                  src={lessonUrl}
+                  title={lessonDisplayName}
+                  className="w-full flex-1"
+                  loading="lazy"
+                  allow="fullscreen; clipboard-read; clipboard-write; accelerometer; gyroscope"
+                  allowFullScreen
+                />
+              </>
+            ) : (
+              <div className="flex-1 flex items-center justify-center p-6 text-sm text-slate-500 text-center">
+                Mini lesson link is not available yet. Please check back soon.
+              </div>
+            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- simplify the short lesson hook to fetch the Vercel URL returned by the mini lesson API and surface loading/error states
- render the fetched Vercel link inside the short lesson page iframe with an "open in new tab" shortcut

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d39b28cce0832f9c4ad0c7fdb74b24