### PR TITLE
Connect classroom chat to backend chat API

### DIFF
--- a/src/pages/ClassroomPage.jsx
+++ b/src/pages/ClassroomPage.jsx
@@ -1,6 +1,7 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { Tldraw } from 'tldraw'
 import 'tldraw/tldraw.css'
+import { sendChatMessage } from '../services/chatService'
 
 function ChatDock({
   title = 'Ask, learn, brainstorm, draw',
@@ -131,13 +132,8 @@ function ChatDock({
 
 // --- Page: Tldraw on the left, simple chat on the right ---
 export default function ClassroomPage() {
-  // Example onSend that simply echoes back a canned response.
-  // Replace with your backend call if needed.
-  const onSend = useMemo(() => {
-    return async (text) => {
-      await new Promise(r => setTimeout(r, 250)) // simulate latency
-      return `You said: "${text}"`
-    }
+  const onSend = useCallback(async (text) => {
+    return await sendChatMessage(text)
   }, [])
 
   return (

--- a/src/services/chatService.js
+++ b/src/services/chatService.js
@@ -1,0 +1,42 @@
+import { API_BASE_URL } from '../config'
+
+function extractErrorMessage(data, status) {
+  if (!data) return `Request failed with status ${status}`
+  if (typeof data === 'string' && data.trim().length > 0) return data
+  if (typeof data.detail === 'string' && data.detail.trim().length > 0) return data.detail
+  if (typeof data.message === 'string' && data.message.trim().length > 0) return data.message
+  return `Request failed with status ${status}`
+}
+
+export async function sendChatMessage(text) {
+  const response = await fetch(`${API_BASE_URL}/chat/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ text }),
+  })
+
+  if (!response.ok) {
+    let errorMessage
+    try {
+      const errorData = await response.json()
+      errorMessage = extractErrorMessage(errorData, response.status)
+    } catch (error) {
+      const fallback = await response.text()
+      errorMessage = fallback?.trim().length ? fallback : `Request failed with status ${response.status}`
+    }
+    throw new Error(errorMessage)
+  }
+
+  const contentType = response.headers.get('content-type') ?? ''
+  if (contentType.includes('application/json')) {
+    const data = await response.json()
+    if (typeof data === 'string') return data
+    if (data && typeof data.text === 'string') return data.text
+    if (data && typeof data.message === 'string') return data.message
+    if (data && typeof data.reply === 'string') return data.reply
+    return 'Message delivered to the classroom service.'
+  }
+
+  const responseText = await response.text()
+  return responseText?.trim().length ? responseText : 'Message delivered to the classroom service.'
+}


### PR DESCRIPTION
## Summary
- add a chat service that posts classroom messages to the backend chat endpoint
- update the classroom chat dock to send messages through the new service

## Testing
- npm run build *(fails: Rollup cannot resolve the optional `tldraw` dependency in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da07ef0378832f845fe4ef00a68e69